### PR TITLE
chore: add niuma workflows and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
+
+      - name: Install N-API deps
+        if: ${{ hashFiles('crates/beautiful-mermaid-napi/package.json') != '' }}
+        run: npm --prefix crates/beautiful-mermaid-napi install
+
+      - name: Build N-API
+        if: ${{ hashFiles('crates/beautiful-mermaid-napi/package.json') != '' }}
+        run: npx --prefix crates/beautiful-mermaid-napi napi build --release
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/niuma-discuss-reusable.yml
+++ b/.github/workflows/niuma-discuss-reusable.yml
@@ -1,0 +1,90 @@
+name: niuma - Discussion Check Reusable
+
+on:
+  workflow_call:
+    inputs:
+      repo:
+        description: "目标仓库（owner/repo）"
+        required: true
+        type: string
+      issue_number:
+        description: "Issue 编号"
+        required: true
+        type: string
+      max_discussion_rounds:
+        description: "最大讨论轮次（1-20）"
+        required: false
+        default: 5
+        type: number
+      visible_round_interval:
+        description: "可见评论轮次间隔"
+        required: false
+        default: 1
+        type: number
+      visible_only_on_diff:
+        description: "仅差异变化时可见评论"
+        required: false
+        default: true
+        type: boolean
+      workflow_source_repo:
+        description: "reusable workflow 源仓库（owner/repo）"
+        required: false
+        default: ""
+        type: string
+      workflow_source_ref:
+        description: "reusable workflow 源 ref（分支、tag 或 SHA）"
+        required: false
+        default: ""
+        type: string
+      repo_dir:
+        description: "仓库目录（相对 GITHUB_WORKSPACE 或绝对路径）"
+        required: false
+        default: "."
+        type: string
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  discussion-check:
+    runs-on: self-hosted
+    timeout-minutes: 30
+    concurrency:
+      group: niuma-discuss-${{ inputs.repo }}-${{ inputs.issue_number }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup niuma binary
+        run: |
+          niuma_path="$(command -v niuma || true)"
+          if [ -z "$niuma_path" ] && [ -x "/usr/local/bin/niuma" ]; then
+            niuma_path="/usr/local/bin/niuma"
+          fi
+          if [ -z "$niuma_path" ]; then
+            echo "::error::找不到 niuma 二进制，请确保 runner 上已安装 niuma（PATH=$PATH）"
+            exit 1
+          fi
+          echo "NIUMA_BIN=$niuma_path" >> "$GITHUB_ENV"
+
+      # 事件驱动启动一次 discuss，后续轮次在进程内循环推进
+      - name: Check Discussion
+        id: discuss
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          REPO: ${{ inputs.repo }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          MAX_DISCUSSION_ROUNDS: ${{ inputs.max_discussion_rounds }}
+          NIUMA_VISIBLE_ROUND_INTERVAL: ${{ inputs.visible_round_interval }}
+          NIUMA_VISIBLE_ONLY_ON_DIFF: ${{ inputs.visible_only_on_diff }}
+        run: |
+          EXTRA_ARGS=()
+          if [ -n "$MAX_DISCUSSION_ROUNDS" ]; then
+            EXTRA_ARGS+=(--max-discussion-rounds "$MAX_DISCUSSION_ROUNDS")
+          fi
+          output="$("$NIUMA_BIN" discuss \
+            --repo "$REPO" \
+            --issue "$ISSUE_NUMBER" \
+            "${EXTRA_ARGS[@]}")"
+          echo "$output"

--- a/.github/workflows/niuma-discuss.yml
+++ b/.github/workflows/niuma-discuss.yml
@@ -1,0 +1,71 @@
+name: niuma - Discussion Check
+
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: "Issue 编号"
+        required: true
+        type: number
+      max_discussion_rounds:
+        description: "最大讨论轮次（1-20）"
+        required: false
+        default: 5
+        type: number
+      visible_round_interval:
+        description: "可见评论轮次间隔"
+        required: false
+        default: 1
+        type: number
+      visible_only_on_diff:
+        description: "仅差异变化时可见评论"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  # issues.labeled → bot:needs-discussion
+  call-discuss-from-label:
+    if: >
+      github.event_name == 'issues' &&
+      github.event.label.name == 'bot:needs-discussion' &&
+      github.event.issue.pull_request == null
+    uses: ./.github/workflows/niuma-discuss-reusable.yml
+    with:
+      repo: ${{ github.repository }}
+      issue_number: ${{ format('{0}', github.event.issue.number) }}
+    secrets: inherit
+
+  # issue_comment.created → 非 bot 用户在非 PR 的 issue 上评论
+  call-discuss-from-comment:
+    if: >
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request == null &&
+      !endsWith(github.actor, '[bot]') &&
+      !contains(vars.BOT_ACTORS || '', github.actor) &&
+      !contains(github.event.comment.body || '', '<!-- BOT:')
+    uses: ./.github/workflows/niuma-discuss-reusable.yml
+    with:
+      repo: ${{ github.repository }}
+      issue_number: ${{ format('{0}', github.event.issue.number) }}
+    secrets: inherit
+
+  # workflow_dispatch → 手动触发
+  call-discuss-from-dispatch:
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/niuma-discuss-reusable.yml
+    with:
+      repo: ${{ github.repository }}
+      issue_number: ${{ format('{0}', inputs.issue) }}
+      max_discussion_rounds: ${{ fromJSON(inputs.max_discussion_rounds) }}
+      visible_round_interval: ${{ fromJSON(inputs.visible_round_interval) }}
+      visible_only_on_diff: ${{ fromJSON(inputs.visible_only_on_diff) }}
+    secrets: inherit

--- a/.github/workflows/niuma-dispatch-completed.yml
+++ b/.github/workflows/niuma-dispatch-completed.yml
@@ -1,0 +1,49 @@
+name: niuma - Dispatch Completed
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+
+jobs:
+  close-after-integration-merge:
+    runs-on: self-hosted
+    if: >
+      github.event.pull_request.merged == true &&
+      (
+        startsWith(github.event.pull_request.base.ref, 'integration/') ||
+        startsWith(github.event.pull_request.head.ref, 'integration/')
+      )
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.NIUMA_PAT || github.token }}
+
+      - name: Setup niuma binary
+        run: |
+          niuma_path="$(command -v niuma || true)"
+          if [ -z "$niuma_path" ] && [ -x "/usr/local/bin/niuma" ]; then
+            niuma_path="/usr/local/bin/niuma"
+          fi
+          if [ -z "$niuma_path" ]; then
+            echo "::error::找不到 niuma 二进制，请确保 runner 上已安装 niuma（PATH=$PATH）"
+            exit 1
+          fi
+          echo "NIUMA_BIN=$niuma_path" >> "$GITHUB_ENV"
+
+      - name: Close merged and dispatch wakeup
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT || github.token }}
+          REPO: ${{ github.repository }}
+          WORKSPACE: ${{ github.workspace }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          "$NIUMA_BIN" control close-merged \
+            --repo "$REPO" \
+            --repo-dir "$WORKSPACE" \
+            --pr "$PR_NUMBER" \
+            --dispatch-wakeup

--- a/.github/workflows/niuma-implement-reusable.yml
+++ b/.github/workflows/niuma-implement-reusable.yml
@@ -1,0 +1,163 @@
+name: niuma - Implement Reusable
+
+on:
+  workflow_call:
+    inputs:
+      repo:
+        description: "目标仓库（owner/repo）"
+        required: true
+        type: string
+      issue_number:
+        description: "Issue 编号"
+        required: true
+        type: string
+      workflow_source_repo:
+        description: "reusable workflow 源仓库（owner/repo）"
+        required: false
+        default: ""
+        type: string
+      workflow_source_ref:
+        description: "reusable workflow 源 ref（分支、tag 或 SHA）"
+        required: false
+        default: ""
+        type: string
+      repo_dir:
+        description: "仓库目录（相对 GITHUB_WORKSPACE 或绝对路径）"
+        required: false
+        default: "."
+        type: string
+      gate_max_retries:
+        description: "Gate 最大重试次数"
+        required: false
+        default: "2"
+        type: string
+      trigger_label:
+        description: "触发本次实现的标签名（用于 gate label 校验）"
+        required: false
+        default: "bot:plan-final"
+        type: string
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: write
+
+jobs:
+  implement:
+    runs-on: self-hosted
+    concurrency:
+      group: niuma-impl-${{ inputs.issue_number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.NIUMA_PAT }}
+          fetch-depth: 0
+
+      - name: Setup niuma binary
+        run: |
+          niuma_path="$(command -v niuma || true)"
+          if [ -z "$niuma_path" ] && [ -x "/usr/local/bin/niuma" ]; then
+            niuma_path="/usr/local/bin/niuma"
+          fi
+          if [ -z "$niuma_path" ]; then
+            echo "::error::找不到 niuma 二进制，请确保 runner 上已安装 niuma（PATH=$PATH）"
+            exit 1
+          fi
+          echo "NIUMA_BIN=$niuma_path" >> "$GITHUB_ENV"
+
+      - name: Resolve repo directory
+        id: resolve_dir
+        env:
+          REPO_DIR: ${{ inputs.repo_dir }}
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          resolved_repo_dir="$REPO_DIR"
+          if [ -z "$resolved_repo_dir" ]; then
+            resolved_repo_dir="."
+          fi
+          if [[ "$resolved_repo_dir" != /* ]]; then
+            resolved_repo_dir="$WORKSPACE/$resolved_repo_dir"
+          fi
+          echo "repo_dir=$resolved_repo_dir" >> "$GITHUB_OUTPUT"
+
+      - name: Gate label check
+        id: gate_label
+        continue-on-error: true
+        env:
+          TRIGGER_LABEL: ${{ inputs.trigger_label }}
+          WORKSPACE: ${{ steps.resolve_dir.outputs.repo_dir }}
+        run: |
+          "$NIUMA_BIN" gate label \
+            --label "$TRIGGER_LABEL" \
+            --type implement \
+            --repo-dir "$WORKSPACE"
+
+      - name: Implement Code
+        if: steps.gate_label.outcome == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          REPO: ${{ inputs.repo }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          WORKSPACE: ${{ steps.resolve_dir.outputs.repo_dir }}
+        run: |
+          "$NIUMA_BIN" fix \
+            --repo "$REPO" \
+            --issue "$ISSUE_NUMBER" \
+            --repo-dir "$WORKSPACE"
+
+      - name: Find PR Number
+        if: steps.gate_label.outcome == 'success'
+        id: find_pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          REPO: ${{ inputs.repo }}
+        run: |
+          # 分页解析 BOT:PR_CREATED marker，取最新 open PR 号
+          if PR_NUMBER=$("$NIUMA_BIN" resolve-pr --repo "$REPO" --issue "$ISSUE_NUMBER"); then
+            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::未在 issue #${ISSUE_NUMBER} 的评论中找到可用 PR 号"
+            echo "pr_number=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Self-check loop (gate + iterate)
+        if: steps.gate_label.outcome == 'success' && steps.find_pr.outputs.pr_number != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          REPO: ${{ inputs.repo }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
+          WORKSPACE: ${{ steps.resolve_dir.outputs.repo_dir }}
+        run: |
+          MAX_RETRIES=2
+          if [[ "${{ inputs.gate_max_retries }}" =~ ^[0-9]+$ ]]; then
+            MAX_RETRIES="${{ inputs.gate_max_retries }}"
+          else
+            echo "::warning::gate_max_retries 非法: '${{ inputs.gate_max_retries }}'，回退为 2"
+          fi
+
+          for ATTEMPT in $(seq 1 $((MAX_RETRIES + 1))); do
+            if "$NIUMA_BIN" gate run \
+                 --repo "$REPO" --issue "$ISSUE_NUMBER" \
+                 --pr "$PR_NUMBER" --repo-dir "$WORKSPACE" \
+                 --max-retries "$MAX_RETRIES" --self-check; then
+              echo "Gate passed on attempt $ATTEMPT"
+              exit 0
+            fi
+
+            if [ "$ATTEMPT" -gt "$MAX_RETRIES" ]; then
+              echo "Gate failed after $MAX_RETRIES retries, running final escalation gate..."
+              "$NIUMA_BIN" gate run \
+                --repo "$REPO" --issue "$ISSUE_NUMBER" \
+                --pr "$PR_NUMBER" --repo-dir "$WORKSPACE" \
+                --max-retries 0
+              exit 1
+            fi
+
+            echo "Gate failed (attempt $ATTEMPT/$MAX_RETRIES), running iterate..."
+            "$NIUMA_BIN" iterate \
+              --repo "$REPO" --issue "$ISSUE_NUMBER" \
+              --pr "$PR_NUMBER" --repo-dir "$WORKSPACE" || true
+          done

--- a/.github/workflows/niuma-implement.yml
+++ b/.github/workflows/niuma-implement.yml
@@ -1,0 +1,58 @@
+# implement 入口模板
+# 使用: automation/niuma/scripts/render_workflows.sh
+name: niuma - Implement
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: write
+
+jobs:
+  route-event:
+    runs-on: self-hosted
+    outputs:
+      decision: ${{ steps.route.outputs.decision }}
+      reason: ${{ steps.route.outputs.reason }}
+      action: ${{ steps.route.outputs.action }}
+    steps:
+      - name: Setup niuma binary
+        run: |
+          niuma_path="$(command -v niuma || true)"
+          if [ -z "$niuma_path" ] && [ -x "/usr/local/bin/niuma" ]; then
+            niuma_path="/usr/local/bin/niuma"
+          fi
+          if [ -z "$niuma_path" ]; then
+            echo "::error::找不到 niuma 二进制，请确保 runner 上已安装 niuma（PATH=$PATH）"
+            exit 1
+          fi
+          echo "NIUMA_BIN=$niuma_path" >> "$GITHUB_ENV"
+
+      - name: Route Event
+        id: route
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          output="$($NIUMA_BIN control route-event \
+            --repo "$REPO" \
+            --workflow "implement" \
+            --event-name "$GITHUB_EVENT_NAME" \
+            --event-path "$GITHUB_EVENT_PATH")"
+          echo "$output"
+          echo "decision=$(echo "$output" | awk -F= '/^decision=/{print $2; exit}')" >> "$GITHUB_OUTPUT"
+          echo "reason=$(echo "$output" | awk -F= '/^reason=/{print $2; exit}')" >> "$GITHUB_OUTPUT"
+          echo "action=$(echo "$output" | awk -F= '/^action=/{print $2; exit}')" >> "$GITHUB_OUTPUT"
+
+  implement:
+    needs: route-event
+    if: needs.route-event.outputs.decision == 'run' && needs.route-event.outputs.action == 'implement'
+    uses: ./.github/workflows/niuma-implement-reusable.yml
+    with:
+      repo: ${{ github.repository }}
+      issue_number: ${{ format('{0}', github.event.issue.number) }}
+      gate_max_retries: ${{ vars.NIUMA_INTEGRATION_GATE_MAX_RETRIES || '2' }}
+      trigger_label: ${{ github.event.label.name }}
+    secrets: inherit

--- a/.github/workflows/niuma-iterate-reusable.yml
+++ b/.github/workflows/niuma-iterate-reusable.yml
@@ -1,0 +1,215 @@
+name: niuma - Iterate Reusable
+
+on:
+  workflow_call:
+    inputs:
+      repo:
+        description: "目标仓库（owner/repo）"
+        required: true
+        type: string
+      issue_number:
+        description: "Issue 编号（review 路径必填，human 路径可空由 Go 自动解析）"
+        required: false
+        default: ""
+        type: string
+      pr_number:
+        description: "PR 编号（human 路径传入，review 路径自动解析）"
+        required: false
+        default: ""
+        type: string
+      trigger_source:
+        description: "触发来源：review（AI 自审不通过）或 human（人工 changes_requested）"
+        required: true
+        type: string
+      workflow_source_repo:
+        description: "reusable workflow 源仓库（owner/repo）"
+        required: false
+        default: ""
+        type: string
+      workflow_source_ref:
+        description: "reusable workflow 源 ref（分支、tag 或 SHA）"
+        required: false
+        default: ""
+        type: string
+      repo_dir:
+        description: "仓库目录（相对 GITHUB_WORKSPACE 或绝对路径）"
+        required: false
+        default: "."
+        type: string
+      gate_max_retries:
+        description: "Gate 最大重试次数"
+        required: false
+        default: "2"
+        type: string
+      initial_pr_state:
+        description: "caller 透传的 PR 初始状态"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: write
+
+jobs:
+  iterate:
+    runs-on: self-hosted
+    concurrency:
+      group: niuma-iterate-${{ inputs.issue_number || inputs.pr_number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.NIUMA_PAT }}
+          fetch-depth: 0
+
+      - name: Setup niuma binary
+        run: |
+          niuma_path="$(command -v niuma || true)"
+          if [ -z "$niuma_path" ] && [ -x "/usr/local/bin/niuma" ]; then
+            niuma_path="/usr/local/bin/niuma"
+          fi
+          if [ -z "$niuma_path" ]; then
+            echo "::error::找不到 niuma 二进制，请确保 runner 上已安装 niuma（PATH=$PATH）"
+            exit 1
+          fi
+          echo "NIUMA_BIN=$niuma_path" >> "$GITHUB_ENV"
+
+      - name: Resolve repo directory
+        id: resolve_dir
+        env:
+          REPO_DIR: ${{ inputs.repo_dir }}
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          resolved_repo_dir="$REPO_DIR"
+          if [ -z "$resolved_repo_dir" ]; then
+            resolved_repo_dir="."
+          fi
+          if [[ "$resolved_repo_dir" != /* ]]; then
+            resolved_repo_dir="$WORKSPACE/$resolved_repo_dir"
+          fi
+          echo "repo_dir=$resolved_repo_dir" >> "$GITHUB_OUTPUT"
+
+      - name: Find PR Number
+        id: find_pr
+        if: inputs.trigger_source == 'review'
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          REPO: ${{ inputs.repo }}
+        run: |
+          if PR_NUMBER=$("$NIUMA_BIN" resolve-pr --repo "$REPO" --issue "$ISSUE_NUMBER"); then
+            echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::未在 issue #${ISSUE_NUMBER} 的评论中找到可用 PR 号"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check PR State
+        id: pr_state
+        if: inputs.trigger_source == 'review' && steps.find_pr.outputs.pr_number != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
+        run: |
+          PR_STATE=$(gh pr view "$PR_NUMBER" --json state -q '.state')
+          echo "pr_state=$PR_STATE" >> "$GITHUB_OUTPUT"
+
+      - name: Iterate on Review (from bot review)
+        id: iterate_review
+        if: inputs.trigger_source == 'review' && steps.find_pr.outputs.pr_number != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          REPO: ${{ inputs.repo }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
+          PR_STATE: ${{ steps.pr_state.outputs.pr_state }}
+          WORKSPACE: ${{ steps.resolve_dir.outputs.repo_dir }}
+        run: |
+          output="$("$NIUMA_BIN" iterate \
+            --repo "$REPO" \
+            --issue "$ISSUE_NUMBER" \
+            --pr "$PR_NUMBER" \
+            --repo-dir "$WORKSPACE" \
+            --trigger-source review \
+            --pr-state "$PR_STATE")"
+          echo "$output"
+          decision="$(echo "$output" | awk -F= '/^decision=/{print $2; exit}')"
+          issue="$(echo "$output" | awk -F= '/^issue=/{print $2; exit}')"
+          echo "decision=$decision" >> "$GITHUB_OUTPUT"
+          echo "issue_number=$issue" >> "$GITHUB_OUTPUT"
+
+      - name: Run PR Gate (from bot review)
+        if: steps.iterate_review.outputs.decision == 'run' && steps.find_pr.outputs.pr_number != '' && steps.iterate_review.outputs.issue_number != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          REPO: ${{ inputs.repo }}
+          ISSUE_NUMBER: ${{ steps.iterate_review.outputs.issue_number }}
+          PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
+          WORKSPACE: ${{ steps.resolve_dir.outputs.repo_dir }}
+        run: |
+          GATE_MAX_RETRIES=2
+          if [[ "${{ inputs.gate_max_retries }}" =~ ^[0-9]+$ ]]; then
+            GATE_MAX_RETRIES="${{ inputs.gate_max_retries }}"
+          else
+            echo "::warning::gate_max_retries 非法: '${{ inputs.gate_max_retries }}'，回退为 2"
+          fi
+
+          "$NIUMA_BIN" gate run \
+            --repo "$REPO" \
+            --issue "$ISSUE_NUMBER" \
+            --pr "$PR_NUMBER" \
+            --repo-dir "$WORKSPACE" \
+            --max-retries "$GATE_MAX_RETRIES"
+
+      - name: Iterate on Review (from human)
+        id: iterate_human
+        if: inputs.trigger_source == 'human' && inputs.pr_number != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          REPO: ${{ inputs.repo }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          PR_STATE: ${{ inputs.initial_pr_state }}
+          WORKSPACE: ${{ steps.resolve_dir.outputs.repo_dir }}
+        run: |
+          extra_issue_args=()
+          if [ -n "$ISSUE_NUMBER" ]; then
+            extra_issue_args+=(--issue "$ISSUE_NUMBER")
+          fi
+          output="$("$NIUMA_BIN" iterate \
+            --repo "$REPO" \
+            --pr "$PR_NUMBER" \
+            --repo-dir "$WORKSPACE" \
+            --trigger-source human \
+            --pr-state "$PR_STATE" \
+            "${extra_issue_args[@]}")"
+          echo "$output"
+          decision="$(echo "$output" | awk -F= '/^decision=/{print $2; exit}')"
+          issue="$(echo "$output" | awk -F= '/^issue=/{print $2; exit}')"
+          echo "decision=$decision" >> "$GITHUB_OUTPUT"
+          echo "issue_number=$issue" >> "$GITHUB_OUTPUT"
+
+      - name: Run PR Gate (from human)
+        if: steps.iterate_human.outputs.decision == 'run' && inputs.pr_number != '' && steps.iterate_human.outputs.issue_number != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          REPO: ${{ inputs.repo }}
+          ISSUE_NUMBER: ${{ steps.iterate_human.outputs.issue_number }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          WORKSPACE: ${{ steps.resolve_dir.outputs.repo_dir }}
+        run: |
+          GATE_MAX_RETRIES=2
+          if [[ "${{ inputs.gate_max_retries }}" =~ ^[0-9]+$ ]]; then
+            GATE_MAX_RETRIES="${{ inputs.gate_max_retries }}"
+          else
+            echo "::warning::gate_max_retries 非法: '${{ inputs.gate_max_retries }}'，回退为 2"
+          fi
+
+          "$NIUMA_BIN" gate run \
+            --repo "$REPO" \
+            --issue "$ISSUE_NUMBER" \
+            --pr "$PR_NUMBER" \
+            --repo-dir "$WORKSPACE" \
+            --max-retries "$GATE_MAX_RETRIES"

--- a/.github/workflows/niuma-iterate.yml
+++ b/.github/workflows/niuma-iterate.yml
@@ -1,0 +1,41 @@
+name: niuma - Iterate
+
+on:
+  issues:
+    types: [labeled]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: write
+
+jobs:
+  # AI 自审不通过 -> 自动迭代
+  call-iterate-from-review:
+    if: >
+      github.event_name == 'issues' &&
+      github.event.label.name == 'bot:pr-needs-fix' &&
+      github.event.issue.state == 'open'
+    uses: ./.github/workflows/niuma-iterate-reusable.yml
+    with:
+      repo: ${{ github.repository }}
+      issue_number: ${{ format('{0}', github.event.issue.number) }}
+      trigger_source: review
+      gate_max_retries: ${{ vars.NIUMA_INTEGRATION_GATE_MAX_RETRIES || '2' }}
+    secrets: inherit
+
+  # 人工 PR review changes_requested -> 直接透传上下文给 Go 处理
+  call-iterate-from-human:
+    if: >
+      github.event_name == 'pull_request_review' &&
+      github.event.review.state == 'changes_requested'
+    uses: ./.github/workflows/niuma-iterate-reusable.yml
+    with:
+      repo: ${{ github.repository }}
+      pr_number: ${{ format('{0}', github.event.pull_request.number) }}
+      trigger_source: human
+      gate_max_retries: ${{ vars.NIUMA_INTEGRATION_GATE_MAX_RETRIES || '2' }}
+      initial_pr_state: ${{ github.event.pull_request.state }}
+    secrets: inherit

--- a/.github/workflows/niuma-label-guard.yml
+++ b/.github/workflows/niuma-label-guard.yml
@@ -1,0 +1,47 @@
+name: niuma - Label Guard
+
+on:
+  issues:
+    types: [labeled, unlabeled]
+
+jobs:
+  guard:
+    runs-on: self-hosted
+    if: startsWith(github.event.label.name, 'bot:')
+    concurrency:
+      group: niuma-label-guard-${{ github.repository }}-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.NIUMA_PAT || github.token }}
+
+      - name: Setup niuma binary
+        run: |
+          niuma_path="$(command -v niuma || true)"
+          if [ -z "$niuma_path" ] && [ -x "/usr/local/bin/niuma" ]; then
+            niuma_path="/usr/local/bin/niuma"
+          fi
+          if [ -z "$niuma_path" ]; then
+            echo "::error::找不到 niuma 二进制，请确保 runner 上已安装 niuma（PATH=$PATH）"
+            exit 1
+          fi
+          echo "NIUMA_BIN=$niuma_path" >> "$GITHUB_ENV"
+
+      - name: Run label guard
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ACTOR: ${{ github.actor }}
+          ACTION: ${{ github.event.action }}
+          LABEL: ${{ github.event.label.name }}
+        run: |
+          "$NIUMA_BIN" label-guard \
+            --repo "$REPO" \
+            --issue "$ISSUE_NUMBER" \
+            --actor "$ACTOR" \
+            --action "$ACTION" \
+            --label "$LABEL"

--- a/.github/workflows/niuma-orchestrate-reusable.yml
+++ b/.github/workflows/niuma-orchestrate-reusable.yml
@@ -1,0 +1,397 @@
+name: niuma - Orchestrate Reusable
+
+on:
+  workflow_call:
+    inputs:
+      repo:
+        description: "目标仓库（owner/repo）"
+        required: true
+        type: string
+      workflow_source_repo:
+        description: "reusable workflow 源仓库（owner/repo）"
+        required: false
+        default: ""
+        type: string
+      workflow_source_ref:
+        description: "reusable workflow 源 ref（分支、tag 或 SHA）"
+        required: false
+        default: ""
+        type: string
+      repo_dir:
+        description: "仓库目录（相对 GITHUB_WORKSPACE 或绝对路径）"
+        required: false
+        default: "."
+        type: string
+      event_id:
+        description: "外部事件唯一标识；为空时退化到 run 级唯一键"
+        required: false
+        default: ""
+        type: string
+      dedup_window_hours:
+        description: "event_id 去重窗口（小时，正整数）"
+        required: false
+        default: 24
+        type: number
+      concurrency_key:
+        description: "并发串行键；默认支持 ${repo} 占位"
+        required: false
+        default: "niuma-orchestrate-${repo}"
+        type: string
+      enable_local_cleanup:
+        description: "是否启用 PR 合并后的本地 worktree/branch 清理"
+        required: false
+        default: false
+        type: boolean
+      store_dir:
+        description: "tasks.json 存储目录（多 runner 共享场景，绝对路径）"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  orchestrate:
+    runs-on: self-hosted
+    concurrency:
+      group: ${{ inputs.concurrency_key == 'niuma-orchestrate-${repo}' && format('niuma-orchestrate-{0}', inputs.repo) || inputs.concurrency_key }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.NIUMA_PAT || github.token }}
+
+      - name: Resolve Trigger Context
+        id: trigger_context
+        run: |
+          trigger_source="${GITHUB_EVENT_NAME}"
+          issue=""
+          label_name="${{ github.event.label.name }}"
+          payload_source="${{ github.event.client_payload.event_source }}"
+          raw_event_id="${{ inputs.event_id }}"
+          event_id_from_external="false"
+
+          if [ "$GITHUB_EVENT_NAME" = "issues" ]; then
+            trigger_source="issues:${label_name}"
+            issue="${{ github.event.issue.number }}"
+          elif [ "$GITHUB_EVENT_NAME" = "repository_dispatch" ]; then
+            if [ -n "$payload_source" ]; then
+              trigger_source="repository_dispatch:${payload_source}"
+            else
+              trigger_source="repository_dispatch:${{ github.event.action }}"
+            fi
+            issue="${{ github.event.client_payload.source_issue }}"
+            if [ -z "$issue" ]; then
+              issue="${{ github.event.client_payload.trigger_pr }}"
+            fi
+          elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            if [ "${{ github.event.pull_request.merged }}" = "true" ]; then
+              trigger_source="pull_request:merged"
+            else
+              trigger_source="pull_request:closed"
+            fi
+            issue="pr-${{ github.event.pull_request.number }}"
+          elif [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+            trigger_source="schedule"
+          fi
+
+          if [ -z "$issue" ]; then
+            issue="schedule"
+          fi
+
+          if [ -z "$raw_event_id" ]; then
+            raw_event_id="${{ github.event.client_payload.event_id }}"
+          fi
+          if [ -z "$raw_event_id" ] && [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            raw_event_id="pr-${{ github.event.pull_request.number }}-merge-${{ github.event.pull_request.merge_commit_sha }}"
+          fi
+          if [ -n "$raw_event_id" ]; then
+            event_id="$raw_event_id"
+            event_id_from_external="true"
+          else
+            event_id="run-${GITHUB_RUN_ID}-attempt-${GITHUB_RUN_ATTEMPT}"
+          fi
+
+          triggered_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "trigger_source=$trigger_source" >> "$GITHUB_OUTPUT"
+          echo "issue=$issue" >> "$GITHUB_OUTPUT"
+          echo "event_id=$event_id" >> "$GITHUB_OUTPUT"
+          echo "event_id_from_external=$event_id_from_external" >> "$GITHUB_OUTPUT"
+          echo "triggered_at=$triggered_at" >> "$GITHUB_OUTPUT"
+          printf '[orchestrate.trigger] {"trigger_source":"%s","issue":"%s","event_id":"%s","triggered_at":"%s"}\n' \
+            "$trigger_source" "$issue" "$event_id" "$triggered_at"
+
+      - name: Setup niuma binary
+        run: |
+          niuma_path="$(command -v niuma || true)"
+          # 某些 self-hosted runner 服务环境 PATH 不含 /usr/local/bin，补绝对路径兜底。
+          if [ -z "$niuma_path" ] && [ -x "/usr/local/bin/niuma" ]; then
+            niuma_path="/usr/local/bin/niuma"
+          fi
+          if [ -z "$niuma_path" ]; then
+            echo "::error::找不到 niuma 二进制，请确保 runner 上已安装 niuma（PATH=$PATH）"
+            exit 1
+          fi
+          echo "NIUMA_BIN=$niuma_path" >> "$GITHUB_ENV"
+
+      - name: Route Event in Control
+        id: route_event
+        env:
+          REPO: ${{ inputs.repo }}
+        run: |
+          output="$("$NIUMA_BIN" control route-event \
+            --repo "$REPO" \
+            --workflow "orchestrate" \
+            --event-name "$GITHUB_EVENT_NAME" \
+            --event-path "$GITHUB_EVENT_PATH")"
+          echo "$output"
+          decision="$(echo "$output" | awk -F= '/^decision=/{print $2; exit}')"
+          reason="$(echo "$output" | awk -F= '/^reason=/{print $2; exit}')"
+          action="$(echo "$output" | awk -F= '/^action=/{print $2; exit}')"
+          echo "decision=$decision" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+          echo "action=$action" >> "$GITHUB_OUTPUT"
+
+      - name: Loop Guard
+        id: loop_guard
+        run: |
+          blocked="false"
+          reason="none"
+
+          if [ "$GITHUB_EVENT_NAME" = "issues" ] && [ "${GITHUB_ACTOR}" = "github-actions[bot]" ]; then
+            blocked="true"
+            reason="issues_actor_bot"
+          fi
+
+          echo "blocked=$blocked" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+          printf '[orchestrate.loop_guard] {"blocked":"%s","reason":"%s"}\n' "$blocked" "$reason"
+
+      - name: Idempotency Guard
+        id: idempotency_guard
+        run: |
+          duplicate_event="false"
+          dedup_reason="not_applicable"
+
+          if [ "${{ steps.trigger_context.outputs.event_id_from_external }}" != "true" ]; then
+            dedup_reason="run_level_unique"
+            echo "duplicate_event=$duplicate_event" >> "$GITHUB_OUTPUT"
+            echo "reason=$dedup_reason" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          safe_repo="$(echo "${{ inputs.repo }}" | tr '/:' '__')"
+          dedup_dir="/tmp/niuma-orchestrate-dedup/${safe_repo}"
+          event_hash="$(printf '%s' "${{ steps.trigger_context.outputs.event_id }}" | sha256sum | awk '{print $1}')"
+          marker_file="${dedup_dir}/${event_hash}.ts"
+          now_epoch="$(date +%s)"
+          window_hours_raw="${{ inputs.dedup_window_hours }}"
+          if ! echo "$window_hours_raw" | grep -Eq '^[1-9][0-9]*$'; then
+            echo "::error::dedup_window_hours 必须为正整数，当前值: $window_hours_raw"
+            exit 1
+          fi
+          window_hours="$window_hours_raw"
+          window_seconds=$((window_hours * 3600))
+
+          mkdir -p "$dedup_dir"
+          # 清理窗口外历史标记，避免本地 runner 长期累积。
+          find "$dedup_dir" -type f -mmin "+$((window_hours * 60))" -delete 2>/dev/null || true
+
+          if [ -f "$marker_file" ]; then
+            seen_epoch="$(cat "$marker_file" 2>/dev/null || echo 0)"
+            if [ "$seen_epoch" -gt 0 ] && [ $((now_epoch - seen_epoch)) -le "$window_seconds" ]; then
+              duplicate_event="true"
+              dedup_reason="duplicate_event_id"
+            fi
+          fi
+
+          if [ "$duplicate_event" != "true" ]; then
+            echo "$now_epoch" > "$marker_file"
+            dedup_reason="first_seen"
+          fi
+
+          echo "duplicate_event=$duplicate_event" >> "$GITHUB_OUTPUT"
+          echo "reason=$dedup_reason" >> "$GITHUB_OUTPUT"
+          printf '[orchestrate.idempotency] {"event_id":"%s","duplicate_event":"%s","reason":"%s"}\n' \
+            "${{ steps.trigger_context.outputs.event_id }}" "$duplicate_event" "$dedup_reason"
+
+      - name: Run Orchestration
+        id: control_run
+        if: steps.route_event.outputs.decision == 'run' && steps.route_event.outputs.action == 'orchestrate' && steps.loop_guard.outputs.blocked != 'true' && steps.idempotency_guard.outputs.duplicate_event != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT || github.token }}
+          REPO: ${{ inputs.repo }}
+          REPO_DIR: ${{ inputs.repo_dir }}
+          WORKSPACE: ${{ github.workspace }}
+          NIUMA_INTEGRATION_GATE_MAX_RETRIES: ${{ vars.NIUMA_INTEGRATION_GATE_MAX_RETRIES || '2' }}
+          NIUMA_PR_CONFLICT_RETRY_THRESHOLD: ${{ vars.NIUMA_PR_CONFLICT_RETRY_THRESHOLD || '3' }}
+          NIUMA_PR_CONFLICT_UNKNOWN_BACKOFFS: ${{ vars.NIUMA_PR_CONFLICT_UNKNOWN_BACKOFFS || '5s,15s,30s' }}
+          NIUMA_STORE_DIR: ${{ inputs.store_dir }}
+        run: |
+          resolved_repo_dir="$REPO_DIR"
+          if [ -z "$resolved_repo_dir" ]; then
+            resolved_repo_dir="."
+          fi
+          if [[ "$resolved_repo_dir" != /* ]]; then
+            resolved_repo_dir="$WORKSPACE/$resolved_repo_dir"
+          fi
+
+          "$NIUMA_BIN" control run \
+            --repo "$REPO" \
+            --repo-dir "$resolved_repo_dir" \
+            --integration-gate-max-retries "$NIUMA_INTEGRATION_GATE_MAX_RETRIES" \
+            --pr-conflict-retry-threshold "$NIUMA_PR_CONFLICT_RETRY_THRESHOLD" \
+            --pr-conflict-unknown-backoffs "$NIUMA_PR_CONFLICT_UNKNOWN_BACKOFFS"
+
+      - name: Collect Integration Gate Status
+        id: gate_status
+        if: steps.control_run.outcome == 'success'
+        env:
+          REPO_DIR: ${{ inputs.repo_dir }}
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          resolved_repo_dir="$REPO_DIR"
+          if [ -z "$resolved_repo_dir" ]; then
+            resolved_repo_dir="."
+          fi
+          if [[ "$resolved_repo_dir" != /* ]]; then
+            resolved_repo_dir="$WORKSPACE/$resolved_repo_dir"
+          fi
+
+          STORE_DIR="${{ inputs.store_dir }}"
+          if [ -n "$STORE_DIR" ]; then
+            STORE_PATH="$STORE_DIR/tasks.json"
+          else
+            STORE_PATH="$resolved_repo_dir/.niuma/tasks.json"
+          fi
+          if [ ! -f "$STORE_PATH" ]; then
+            echo "integration_gate_status=passed" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          STATUS=$(jq -r '
+            [ (.tasks // {}) | to_entries[] | .value.metadata.integration_gate_status // empty ] as $s |
+            if ($s | index("escalated")) then "escalated"
+            elif ($s | index("retrying")) then "retrying"
+            elif ($s | index("pending")) then "pending"
+            elif ($s | index("passed")) then "passed"
+            else "passed" end
+          ' "$STORE_PATH")
+          echo "integration_gate_status=$STATUS" >> "$GITHUB_OUTPUT"
+          echo "integration_gate_status=$STATUS"
+
+      - name: Log Orchestrate Result
+        if: always()
+        run: |
+          result="success"
+          if [ "${{ steps.route_event.outputs.decision }}" != "run" ]; then
+            result="skipped_${{ steps.route_event.outputs.reason }}"
+          elif [ "${{ steps.loop_guard.outputs.blocked }}" = "true" ]; then
+            result="skipped_${{ steps.loop_guard.outputs.reason }}"
+          elif [ "${{ steps.idempotency_guard.outputs.duplicate_event }}" = "true" ]; then
+            result="deduplicated_noop"
+          elif [ "${{ steps.control_run.outcome }}" != "success" ]; then
+            result="control_failed"
+          elif [ -n "${{ steps.gate_status.outputs.integration_gate_status }}" ]; then
+            result="gate_${{ steps.gate_status.outputs.integration_gate_status }}"
+          fi
+
+          printf '[orchestrate.result] {"trigger_source":"%s","issue":"%s","event_id":"%s","triggered_at":"%s","result":"%s"}\n' \
+            "${{ steps.trigger_context.outputs.trigger_source }}" \
+            "${{ steps.trigger_context.outputs.issue }}" \
+            "${{ steps.trigger_context.outputs.event_id }}" \
+            "${{ steps.trigger_context.outputs.triggered_at }}" \
+            "$result"
+
+  cleanup_local_worktrees:
+    runs-on: self-hosted
+    if: >
+      inputs.enable_local_cleanup &&
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'master'
+    concurrency:
+      group: ${{ format('cleanup-{0}-{1}', github.repository, github.event.pull_request.number) }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.NIUMA_PAT || github.token }}
+          fetch-depth: 0
+
+      - name: Resolve Reusable Workflow Source
+        id: workflow_source
+        env:
+          INPUT_SOURCE_REPO: ${{ inputs.workflow_source_repo }}
+          INPUT_SOURCE_REF: ${{ inputs.workflow_source_ref }}
+          DEFAULT_SOURCE_REPO: ${{ github.repository }}
+          DEFAULT_SOURCE_REF: ${{ github.event.repository.default_branch }}
+        run: |
+          source_repo="$INPUT_SOURCE_REPO"
+          source_ref="$INPUT_SOURCE_REF"
+
+          if [ -z "$source_repo" ]; then
+            source_repo="$DEFAULT_SOURCE_REPO"
+          fi
+          if [ -z "$source_ref" ]; then
+            source_ref="$DEFAULT_SOURCE_REF"
+          fi
+
+          if [ -z "$source_repo" ] || [ -z "$source_ref" ]; then
+            echo "::error::无法解析 reusable workflow 源仓库/ref，请显式传入 workflow_source_repo 与 workflow_source_ref"
+            exit 1
+          fi
+
+          echo "source_repo=$source_repo" >> "$GITHUB_OUTPUT"
+          echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout Reusable Workflow Source
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.workflow_source.outputs.source_repo }}
+          ref: ${{ steps.workflow_source.outputs.source_ref }}
+          path: .niuma-workflow-source
+          token: ${{ secrets.NIUMA_PAT || github.token }}
+          fetch-depth: 1
+
+      - name: Run Local Worktree Cleanup
+        id: cleanup
+        env:
+          REPO_DIR: ${{ inputs.repo_dir }}
+          WORKSPACE: ${{ github.workspace }}
+          WORKFLOW_SOURCE_DIR: ${{ github.workspace }}/.niuma-workflow-source
+        run: |
+          resolved_repo_dir="$REPO_DIR"
+          if [ -z "$resolved_repo_dir" ]; then
+            resolved_repo_dir="."
+          fi
+          if [[ "$resolved_repo_dir" != /* ]]; then
+            resolved_repo_dir="$WORKSPACE/$resolved_repo_dir"
+          fi
+
+          script_path="$WORKFLOW_SOURCE_DIR/automation/niuma/scripts/cleanup_worktrees.sh"
+          if [ ! -x "$script_path" ]; then
+            echo "::error::cleanup 脚本不存在或不可执行: $script_path"
+            exit 1
+          fi
+
+          "$script_path" --repo-dir "$resolved_repo_dir"
+
+      - name: Write Cleanup Summary
+        if: always()
+        run: |
+          echo "## Local Cleanup Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- deleted_count: ${{ steps.cleanup.outputs.deleted_count || '0' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- skipped_count: ${{ steps.cleanup.outputs.skipped_count || '0' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- warned_count: ${{ steps.cleanup.outputs.warned_count || '0' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- error_count: ${{ steps.cleanup.outputs.error_count || '0' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- deleted: \`${{ steps.cleanup.outputs.deleted || '[]' }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- skipped: \`${{ steps.cleanup.outputs.skipped || '[]' }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- warned: \`${{ steps.cleanup.outputs.warned || '[]' }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- errors: \`${{ steps.cleanup.outputs.errors || '[]' }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/niuma-orchestrate.yml
+++ b/.github/workflows/niuma-orchestrate.yml
@@ -1,0 +1,28 @@
+name: niuma - Orchestrate
+
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [closed]
+  repository_dispatch:
+    types: [niuma.task.completed]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  orchestrate:
+    uses: ./.github/workflows/niuma-orchestrate-reusable.yml
+    secrets: inherit
+    with:
+      repo: ${{ github.repository }}
+      store_dir: /home/wangbo/.niuma/stores/beautiful-mermaid
+      workflow_source_repo: ${{ github.repository }}
+      workflow_source_ref: ${{ github.event.repository.default_branch }}
+      repo_dir: "."
+      event_id: ${{ github.event.client_payload.event_id || '' }}
+      dedup_window_hours: 24
+      concurrency_key: "niuma-orchestrate-${repo}"
+      enable_local_cleanup: false

--- a/.github/workflows/niuma-plan-reusable.yml
+++ b/.github/workflows/niuma-plan-reusable.yml
@@ -1,0 +1,81 @@
+name: niuma - Plan Draft Reusable
+
+on:
+  workflow_call:
+    inputs:
+      repo:
+        description: "目标仓库（owner/repo）"
+        required: true
+        type: string
+      issue_number:
+        description: "Issue 编号"
+        required: true
+        type: string
+      workflow_source_repo:
+        description: "reusable workflow 源仓库（owner/repo）"
+        required: false
+        default: ""
+        type: string
+      workflow_source_ref:
+        description: "reusable workflow 源 ref（分支、tag 或 SHA）"
+        required: false
+        default: ""
+        type: string
+      repo_dir:
+        description: "仓库目录（相对 GITHUB_WORKSPACE 或绝对路径）"
+        required: false
+        default: "."
+        type: string
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  plan-draft:
+    runs-on: self-hosted
+    concurrency:
+      group: niuma-plan-${{ inputs.issue_number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup niuma binary
+        run: |
+          niuma_path="$(command -v niuma || true)"
+          if [ -z "$niuma_path" ] && [ -x "/usr/local/bin/niuma" ]; then
+            niuma_path="/usr/local/bin/niuma"
+          fi
+          if [ -z "$niuma_path" ]; then
+            echo "::error::找不到 niuma 二进制，请确保 runner 上已安装 niuma（PATH=$PATH）"
+            exit 1
+          fi
+          echo "NIUMA_BIN=$niuma_path" >> "$GITHUB_ENV"
+
+      - name: Check if issue is in orchestration queue
+        id: check_orchestration
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          REPO: ${{ inputs.repo }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          # 检查 issue 是否在 taskctl 中（被编排队列管理）
+          if "$NIUMA_BIN" control check --repo "$REPO" --issue "$ISSUE_NUMBER" 2>/dev/null; then
+            echo "Issue is in orchestration queue, skipping single-issue flow"
+            echo "should_skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_skip=false" >> $GITHUB_OUTPUT
+          fi
+        continue-on-error: true
+
+      - name: Generate Plan Draft
+        if: steps.check_orchestration.outputs.should_skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          REPO: ${{ inputs.repo }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+        run: |
+          "$NIUMA_BIN" plan-draft \
+            --repo "$REPO" \
+            --issue "$ISSUE_NUMBER"

--- a/.github/workflows/niuma-plan.yml
+++ b/.github/workflows/niuma-plan.yml
@@ -1,0 +1,56 @@
+# plan 入口模板
+# 使用: automation/niuma/scripts/render_workflows.sh
+name: niuma - Plan Draft
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  route-event:
+    runs-on: self-hosted
+    outputs:
+      decision: ${{ steps.route.outputs.decision }}
+      reason: ${{ steps.route.outputs.reason }}
+      action: ${{ steps.route.outputs.action }}
+    steps:
+      - name: Setup niuma binary
+        run: |
+          niuma_path="$(command -v niuma || true)"
+          if [ -z "$niuma_path" ] && [ -x "/usr/local/bin/niuma" ]; then
+            niuma_path="/usr/local/bin/niuma"
+          fi
+          if [ -z "$niuma_path" ]; then
+            echo "::error::找不到 niuma 二进制，请确保 runner 上已安装 niuma（PATH=$PATH）"
+            exit 1
+          fi
+          echo "NIUMA_BIN=$niuma_path" >> "$GITHUB_ENV"
+
+      - name: Route Event
+        id: route
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          output="$($NIUMA_BIN control route-event \
+            --repo "$REPO" \
+            --workflow "plan" \
+            --event-name "$GITHUB_EVENT_NAME" \
+            --event-path "$GITHUB_EVENT_PATH")"
+          echo "$output"
+          echo "decision=$(echo "$output" | awk -F= '/^decision=/{print $2; exit}')" >> "$GITHUB_OUTPUT"
+          echo "reason=$(echo "$output" | awk -F= '/^reason=/{print $2; exit}')" >> "$GITHUB_OUTPUT"
+          echo "action=$(echo "$output" | awk -F= '/^action=/{print $2; exit}')" >> "$GITHUB_OUTPUT"
+
+  plan-draft:
+    needs: route-event
+    if: needs.route-event.outputs.decision == 'run' && needs.route-event.outputs.action == 'plan'
+    uses: ./.github/workflows/niuma-plan-reusable.yml
+    with:
+      repo: ${{ github.repository }}
+      issue_number: ${{ format('{0}', github.event.issue.number) }}
+
+    secrets: inherit

--- a/.github/workflows/niuma-review-reusable.yml
+++ b/.github/workflows/niuma-review-reusable.yml
@@ -1,0 +1,134 @@
+name: niuma - Review Reusable
+
+on:
+  workflow_call:
+    inputs:
+      repo:
+        description: "目标仓库（owner/repo）"
+        required: true
+        type: string
+      issue_number:
+        description: "Issue 编号"
+        required: true
+        type: string
+      workflow_source_repo:
+        description: "reusable workflow 源仓库（owner/repo）"
+        required: false
+        default: ""
+        type: string
+      workflow_source_ref:
+        description: "reusable workflow 源 ref（分支、tag 或 SHA）"
+        required: false
+        default: ""
+        type: string
+      repo_dir:
+        description: "仓库目录（相对 GITHUB_WORKSPACE 或绝对路径）"
+        required: false
+        default: "."
+        type: string
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: self-hosted
+    concurrency:
+      group: niuma-review-${{ inputs.issue_number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup niuma binary
+        run: |
+          niuma_path="$(command -v niuma || true)"
+          if [ -z "$niuma_path" ] && [ -x "/usr/local/bin/niuma" ]; then
+            niuma_path="/usr/local/bin/niuma"
+          fi
+          if [ -z "$niuma_path" ]; then
+            echo "::error::找不到 niuma 二进制，请确保 runner 上已安装 niuma（PATH=$PATH）"
+            exit 1
+          fi
+          echo "NIUMA_BIN=$niuma_path" >> "$GITHUB_ENV"
+
+      - name: Find PR Number
+        id: find_pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          REPO: ${{ inputs.repo }}
+        run: |
+          # 分页解析 BOT:PR_CREATED marker，取最新 open PR 号
+          if PR_NUMBER=$("$NIUMA_BIN" resolve-pr --repo "$REPO" --issue "$ISSUE_NUMBER"); then
+            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          else
+            echo "::warning::未在 issue #${ISSUE_NUMBER} 的评论中找到可用 PR 号"
+            echo "pr_number=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run PR Gate
+        id: pr_gate
+        if: steps.find_pr.outputs.pr_number != ''
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
+        run: |
+          if [ -x "./.github/scripts/niuma-test-gate.sh" ]; then
+            echo "检测到自定义门禁脚本，执行..."
+            ./.github/scripts/niuma-test-gate.sh "$PR_NUMBER"
+          else
+            echo "无自定义门禁脚本，检查 GitHub PR status checks..."
+            # 等待 checks 完成（最多等 5 分钟）
+            for i in $(seq 1 30); do
+              PENDING=$(gh pr checks "$PR_NUMBER" --json state --jq '[.[] | select(.state == "PENDING")] | length' 2>/dev/null || echo "0")
+              if [ "$PENDING" = "0" ]; then
+                break
+              fi
+              echo "等待 $PENDING 个 check 完成... ($i/30)"
+              sleep 10
+            done
+            # 检查是否全部通过（排除本 workflow 自身的 review job）
+            FAILED=$(gh pr checks "$PR_NUMBER" --json name,conclusion --jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "failure")] | length' 2>/dev/null || echo "0")
+            if [ "$FAILED" != "0" ]; then
+              echo "::error::PR #$PR_NUMBER 有 $FAILED 个 check 失败"
+              gh pr checks "$PR_NUMBER" --json name,conclusion --jq '.[] | select(.conclusion == "FAILURE" or .conclusion == "failure") | "  ✗ \(.name)"'
+              exit 1
+            fi
+            echo "所有 PR checks 通过"
+          fi
+
+      - name: Restore Workspace After Gate
+        if: steps.find_pr.outputs.pr_number != '' && steps.pr_gate.outcome == 'success'
+        run: |
+          git checkout --force "$GITHUB_SHA"
+
+      - name: Gate Failed -> Transition to PR Needs Fix
+        if: steps.find_pr.outputs.pr_number != '' && steps.pr_gate.outcome == 'failure'
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          REPO: ${{ inputs.repo }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+        run: |
+          "$NIUMA_BIN" state-label set \
+            --repo "$REPO" \
+            --issue "$ISSUE_NUMBER" \
+            --from bot:pr-created \
+            --to bot:pr-needs-fix
+
+      - name: AI Self-Review
+        if: steps.find_pr.outputs.pr_number != '' && steps.pr_gate.outcome == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.NIUMA_PAT }}
+          NIUMA_IMPLEMENTATION_PROVIDER: codex
+          REPO: ${{ inputs.repo }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
+        run: |
+          "$NIUMA_BIN" review \
+            --repo "$REPO" \
+            --issue "$ISSUE_NUMBER" \
+            --pr "$PR_NUMBER"

--- a/.github/workflows/niuma-review.yml
+++ b/.github/workflows/niuma-review.yml
@@ -1,0 +1,56 @@
+# review 入口模板
+# 使用: automation/niuma/scripts/render_workflows.sh
+name: niuma - Review
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  route-event:
+    runs-on: self-hosted
+    outputs:
+      decision: ${{ steps.route.outputs.decision }}
+      reason: ${{ steps.route.outputs.reason }}
+      action: ${{ steps.route.outputs.action }}
+    steps:
+      - name: Setup niuma binary
+        run: |
+          niuma_path="$(command -v niuma || true)"
+          if [ -z "$niuma_path" ] && [ -x "/usr/local/bin/niuma" ]; then
+            niuma_path="/usr/local/bin/niuma"
+          fi
+          if [ -z "$niuma_path" ]; then
+            echo "::error::找不到 niuma 二进制，请确保 runner 上已安装 niuma（PATH=$PATH）"
+            exit 1
+          fi
+          echo "NIUMA_BIN=$niuma_path" >> "$GITHUB_ENV"
+
+      - name: Route Event
+        id: route
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          output="$($NIUMA_BIN control route-event \
+            --repo "$REPO" \
+            --workflow "review" \
+            --event-name "$GITHUB_EVENT_NAME" \
+            --event-path "$GITHUB_EVENT_PATH")"
+          echo "$output"
+          echo "decision=$(echo "$output" | awk -F= '/^decision=/{print $2; exit}')" >> "$GITHUB_OUTPUT"
+          echo "reason=$(echo "$output" | awk -F= '/^reason=/{print $2; exit}')" >> "$GITHUB_OUTPUT"
+          echo "action=$(echo "$output" | awk -F= '/^action=/{print $2; exit}')" >> "$GITHUB_OUTPUT"
+
+  review:
+    needs: route-event
+    if: needs.route-event.outputs.decision == 'run' && needs.route-event.outputs.action == 'review'
+    uses: ./.github/workflows/niuma-review-reusable.yml
+    with:
+      repo: ${{ github.repository }}
+      issue_number: ${{ format('{0}', github.event.issue.number) }}
+
+    secrets: inherit

--- a/.niuma.yml
+++ b/.niuma.yml
@@ -1,0 +1,46 @@
+ai:
+  # 唯一真相源：切换 provider 只需改这里
+  default: codex
+
+  providers:
+    # Claude Code
+    claude:
+      cmd: "cat {prompt_file} | CLAUDECODE= claude -p --output-format text --max-budget-usd 10 --permission-mode acceptEdits --add-dir {workdir}"
+
+    # OpenAI Codex（需要 OPENAI_API_KEY）
+    codex:
+      cmd: "codex exec --sandbox workspace-write --full-auto -C {workdir} - < {prompt_file}"
+      cmd_agent: "codex exec --sandbox workspace-write --full-auto -C {workdir} - < {prompt_file}"
+
+    # Kimi（Moonshot AI）
+    kimi:
+      cmd: "cat {prompt_file} | kimi --print --input-format text --output-format text --final-message-only -w {workdir}"
+
+  # 讨论阶段：多 provider 左右互搏
+  # "default" 占位符自动解析为 ai.default 的值
+  discussion:
+    providers:
+      - default
+      - kimi
+
+  # 实现阶段：空值或 "default" 自动使用 ai.default
+  implementation:
+    provider: default
+
+workflow:
+  max_discussion_rounds: 5
+  discuss_timeout_minutes: 20
+  visible_round_interval: 1
+  visible_only_on_diff: true
+  max_iterate_rounds: 10
+  allowed_prefixes:
+    - "automation/"
+  implement_trigger_labels:
+    - "bot:plan-final"
+
+label_guard:
+  allowlist:
+    - "github-actions[bot]"
+    - "niuma-bot"
+    - "biantaishabi2"
+  mode: "dry-run"

--- a/.niuma.yml.example
+++ b/.niuma.yml.example
@@ -1,0 +1,65 @@
+ai:
+  default: claude
+  
+  # 预定义模板，使用时只需填 api_key
+  templates:
+    claude:
+      type: claude
+      cmd: "cat {prompt_file} | CLAUDECODE= claude -p --output-format text --max-budget-usd 10 --permission-mode acceptEdits --add-dir {workdir}"
+    
+    codex:
+      type: openai
+      base_url: "https://api.openai.com/v1"
+      model: "gpt-4o"
+      # api_key 从环境变量 OPENAI_API_KEY 读取
+    
+    openrouter:
+      type: openai  # OpenAI 兼容格式
+      base_url: "https://openrouter.ai/api/v1"
+      model: "anthropic/claude-3.5-sonnet"
+      # api_key 从环境变量 OPENROUTER_API_KEY 读取
+    
+    ollama:
+      type: ollama
+      base_url: "http://localhost:11434"
+      model: "qwen2.5-coder:14b"
+  
+  # 实际使用的 provider，引用模板
+  providers:
+    claude:
+      template: claude
+    
+    codex:
+      template: codex
+      # 可选覆盖
+      model: "gpt-4o-mini"
+    
+    openrouter:
+      template: openrouter
+    
+    local:
+      template: ollama
+      model: "deepseek-coder:6.7b"
+
+  # 讨论阶段：多 provider 左右互搏
+  discussion:
+    providers:
+      - claude
+      - codex
+
+  # 实现阶段：切换 provider 只需改这里
+  implementation:
+    provider: codex  # ← 切换这里即可
+
+workflow:
+  # 讨论阶段统一使用 debate_ab
+  # discuss 单次 run 内最大轮次（1-20，默认 5）
+  max_discussion_rounds: 5
+  # discuss 命令超时（分钟，1-120，默认 20）
+  discuss_timeout_minutes: 20
+  # 可见评论节流：每 N 轮输出一次（默认 1）
+  visible_round_interval: 1
+  # 可见评论节流：仅在分歧/决策变化时输出（默认 true）
+  visible_only_on_diff: true
+  allowed_prefixes:
+    - "automation/"


### PR DESCRIPTION
## Summary
- add niuma workflows + .niuma config for DAG automation
- switch label-guard/dispatch-completed to use installed niuma binary
- disable local cleanup in orchestrate (no automation/niuma scripts)
- update CI to build N-API before bun tests

## Test plan
- CI workflow builds N-API and runs bun test

## Notes
- Requires self-hosted runner with `niuma` installed
- Requires `NIUMA_PAT` secret for write operations

Closes #41
