### PR TITLE
fix: normalize origin HEAD for worktree base

### DIFF
--- a/.github/workflows/niuma-implement-reusable.yml
+++ b/.github/workflows/niuma-implement-reusable.yml
@@ -54,6 +54,18 @@ jobs:
           token: ${{ secrets.NIUMA_PAT }}
           fetch-depth: 0
 
+      - name: Normalize origin HEAD
+        run: |
+          set -euo pipefail
+          git remote set-head origin -a || true
+          if ! git symbolic-ref refs/remotes/origin/HEAD >/dev/null 2>&1; then
+            if git show-ref --verify --quiet refs/remotes/origin/main; then
+              git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+            elif git show-ref --verify --quiet refs/remotes/origin/master; then
+              git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
+            fi
+          fi
+
       - name: Setup niuma binary
         run: |
           niuma_path="$(command -v niuma || true)"


### PR DESCRIPTION
## Summary\n- normalize origin/HEAD after checkout in implement workflow to avoid master fallback\n\n## Test plan\n- not run (workflow change)\n\nCloses #43