### PR TITLE
fix: sub(#4): port src/multiline-utils.ts (#6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Run tests (rust multiline flag path)
         env:
           BEAUTIFUL_MERMAID_USE_RUST: "1"
+          BEAUTIFUL_MERMAID_NAPI_REQUIRE_NATIVE: "1"
         run: bun test
 
       - name: Type check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,12 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Run tests
+      - name: Run tests (default ts path)
+        run: bun test
+
+      - name: Run tests (rust multiline flag path)
+        env:
+          BEAUTIFUL_MERMAID_USE_RUST: "1"
         run: bun test
 
       - name: Type check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
 name = "beautiful-mermaid-napi"
 version = "0.0.0"
 dependencies = [
+ "beautiful-mermaid-rs",
  "napi",
  "napi-derive",
  "serde",

--- a/crates/beautiful-mermaid-napi/Cargo.toml
+++ b/crates/beautiful-mermaid-napi/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+beautiful-mermaid-rs = { path = "../beautiful-mermaid-rs" }
 
 napi = { version = "2", default-features = false, features = ["napi6"] }
 napi-derive = "2"

--- a/crates/beautiful-mermaid-napi/index.js
+++ b/crates/beautiful-mermaid-napi/index.js
@@ -1,4 +1,43 @@
 import { createRequire } from 'node:module'
 const require = createRequire(import.meta.url)
-const addon = require('./index.node')
+let addon
+
+try {
+  addon = require('./index.node')
+} catch {
+  const tsImpl = require('../../src/multiline-utils.ts')
+
+  const withRustDisabled = (fn, ...args) => {
+    const prev = process.env.BEAUTIFUL_MERMAID_USE_RUST
+    delete process.env.BEAUTIFUL_MERMAID_USE_RUST
+    try {
+      return fn(...args)
+    } finally {
+      if (prev === undefined) delete process.env.BEAUTIFUL_MERMAID_USE_RUST
+      else process.env.BEAUTIFUL_MERMAID_USE_RUST = prev
+    }
+  }
+
+  addon = {
+    echoBuffer: input => input,
+    normalizeBrTags: label => withRustDisabled(tsImpl.normalizeBrTags, label),
+    stripFormattingTags: text => withRustDisabled(tsImpl.stripFormattingTags, text),
+    escapeXml: text => withRustDisabled(tsImpl.escapeXml, text),
+    renderMultilineText: (text, cx, cy, fontSize, attrs, baselineShift) =>
+      withRustDisabled(tsImpl.renderMultilineText, text, cx, cy, fontSize, attrs, baselineShift),
+    renderMultilineTextWithBackground: (
+      text, cx, cy, textWidth, textHeight, fontSize, padding, textAttrs, bgAttrs
+    ) =>
+      withRustDisabled(
+        tsImpl.renderMultilineTextWithBackground,
+        text, cx, cy, textWidth, textHeight, fontSize, padding, textAttrs, bgAttrs
+      ),
+  }
+}
+
 export const echoBuffer = addon.echoBuffer
+export const normalizeBrTags = addon.normalizeBrTags
+export const stripFormattingTags = addon.stripFormattingTags
+export const escapeXml = addon.escapeXml
+export const renderMultilineText = addon.renderMultilineText
+export const renderMultilineTextWithBackground = addon.renderMultilineTextWithBackground

--- a/crates/beautiful-mermaid-napi/index.js
+++ b/crates/beautiful-mermaid-napi/index.js
@@ -1,38 +1,145 @@
 import { createRequire } from 'node:module'
 const require = createRequire(import.meta.url)
+const LINE_HEIGHT_RATIO = 1.3
+const FORMAT_TAG_REGEX = /<(\/)?(?:(b|strong)|(i|em)|(u)|(s|del))\s*>/gi
+const HAS_FORMAT_TAGS = /<\/?(?:b|strong|i|em|u|s|del)\s*>/i
+
+function isNativeRequired() {
+  const flag = process.env.BEAUTIFUL_MERMAID_NAPI_REQUIRE_NATIVE
+  if (!flag) return false
+  const normalized = flag.toLowerCase()
+  return normalized === '1' || normalized === 'true'
+}
+
+function normalizeBrTagsFallback(label) {
+  const unquoted = label.startsWith('"') && label.endsWith('"') ? label.slice(1, -1) : label
+  return unquoted
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/\\n/g, '\n')
+    .replace(/<\/?(?:sub|sup|small|mark)\s*>/gi, '')
+    .replace(/\*\*(.+?)\*\*/g, '<b>$1</b>')
+    .replace(/(?<!\*)\*([^\s*](?:[^*]*[^\s*])?)\*(?!\*)/g, '<i>$1</i>')
+    .replace(/~~(.+?)~~/g, '<s>$1</s>')
+}
+
+function stripFormattingTagsFallback(text) {
+  return text.replace(/<\/?(?:b|strong|i|em|u|s|del)\s*>/gi, '')
+}
+
+function escapeXmlFallback(text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function parseInlineFormatting(line) {
+  const segments = []
+  let bold = false
+  let italic = false
+  let underline = false
+  let strikethrough = false
+  let lastIndex = 0
+
+  FORMAT_TAG_REGEX.lastIndex = 0
+  let match
+  while ((match = FORMAT_TAG_REGEX.exec(line)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ text: line.slice(lastIndex, match.index), bold, italic, underline, strikethrough })
+    }
+    lastIndex = match.index + match[0].length
+
+    const isClosing = Boolean(match[1])
+    if (match[2]) bold = !isClosing
+    else if (match[3]) italic = !isClosing
+    else if (match[4]) underline = !isClosing
+    else if (match[5]) strikethrough = !isClosing
+  }
+
+  if (lastIndex < line.length) {
+    segments.push({ text: line.slice(lastIndex), bold, italic, underline, strikethrough })
+  }
+
+  return segments
+}
+
+function renderLineContentFallback(line) {
+  if (!HAS_FORMAT_TAGS.test(line)) return escapeXmlFallback(line)
+
+  const segments = parseInlineFormatting(line)
+  if (segments.length === 0) return ''
+
+  const allPlain = segments.every(s => !s.bold && !s.italic && !s.underline && !s.strikethrough)
+  if (allPlain) return segments.map(s => escapeXmlFallback(s.text)).join('')
+
+  return segments.map(seg => {
+    const escaped = escapeXmlFallback(seg.text)
+    if (!seg.bold && !seg.italic && !seg.underline && !seg.strikethrough) return escaped
+
+    const attrs = []
+    if (seg.bold) attrs.push('font-weight="bold"')
+    if (seg.italic) attrs.push('font-style="italic"')
+    const deco = []
+    if (seg.underline) deco.push('underline')
+    if (seg.strikethrough) deco.push('line-through')
+    if (deco.length) attrs.push(`text-decoration="${deco.join(' ')}"`)
+
+    return `<tspan ${attrs.join(' ')}>${escaped}</tspan>`
+  }).join('')
+}
+
+function renderMultilineTextFallback(text, cx, cy, fontSize, attrs, baselineShift = 0.35) {
+  const lines = text.split('\n')
+
+  if (lines.length === 1) {
+    const dy = fontSize * baselineShift
+    return `<text x="${cx}" y="${cy}" ${attrs} dy="${dy}">${renderLineContentFallback(text)}</text>`
+  }
+
+  const lineHeight = fontSize * LINE_HEIGHT_RATIO
+  const firstDy = -((lines.length - 1) / 2) * lineHeight + fontSize * baselineShift
+  const tspans = lines.map((line, index) => {
+    const dy = index === 0 ? firstDy : lineHeight
+    return `<tspan x="${cx}" dy="${dy}">${renderLineContentFallback(line)}</tspan>`
+  }).join('')
+  return `<text x="${cx}" y="${cy}" ${attrs}>${tspans}</text>`
+}
+
+function renderMultilineTextWithBackgroundFallback(
+  text, cx, cy, textWidth, textHeight, fontSize, padding, textAttrs, bgAttrs
+) {
+  const bgWidth = textWidth + padding * 2
+  const bgHeight = textHeight + padding * 2
+  const rect = `<rect x="${cx - bgWidth / 2}" y="${cy - bgHeight / 2}" ` +
+    `width="${bgWidth}" height="${bgHeight}" ${bgAttrs} />`
+  const textEl = renderMultilineTextFallback(text, cx, cy, fontSize, textAttrs)
+  return `${rect}\n${textEl}`
+}
+
+function buildFallbackAddon() {
+  return {
+    echoBuffer: input => input,
+    normalizeBrTags: normalizeBrTagsFallback,
+    stripFormattingTags: stripFormattingTagsFallback,
+    escapeXml: escapeXmlFallback,
+    renderMultilineText: renderMultilineTextFallback,
+    renderMultilineTextWithBackground: renderMultilineTextWithBackgroundFallback,
+  }
+}
+
 let addon
+let nativeLoaded = false
 
 try {
   addon = require('./index.node')
-} catch {
-  const tsImpl = require('../../src/multiline-utils.ts')
-
-  const withRustDisabled = (fn, ...args) => {
-    const prev = process.env.BEAUTIFUL_MERMAID_USE_RUST
-    delete process.env.BEAUTIFUL_MERMAID_USE_RUST
-    try {
-      return fn(...args)
-    } finally {
-      if (prev === undefined) delete process.env.BEAUTIFUL_MERMAID_USE_RUST
-      else process.env.BEAUTIFUL_MERMAID_USE_RUST = prev
-    }
+  nativeLoaded = true
+} catch (error) {
+  if (isNativeRequired()) {
+    throw new Error('Failed to load native addon while BEAUTIFUL_MERMAID_NAPI_REQUIRE_NATIVE=1', { cause: error })
   }
-
-  addon = {
-    echoBuffer: input => input,
-    normalizeBrTags: label => withRustDisabled(tsImpl.normalizeBrTags, label),
-    stripFormattingTags: text => withRustDisabled(tsImpl.stripFormattingTags, text),
-    escapeXml: text => withRustDisabled(tsImpl.escapeXml, text),
-    renderMultilineText: (text, cx, cy, fontSize, attrs, baselineShift) =>
-      withRustDisabled(tsImpl.renderMultilineText, text, cx, cy, fontSize, attrs, baselineShift),
-    renderMultilineTextWithBackground: (
-      text, cx, cy, textWidth, textHeight, fontSize, padding, textAttrs, bgAttrs
-    ) =>
-      withRustDisabled(
-        tsImpl.renderMultilineTextWithBackground,
-        text, cx, cy, textWidth, textHeight, fontSize, padding, textAttrs, bgAttrs
-      ),
-  }
+  addon = buildFallbackAddon()
 }
 
 export const echoBuffer = addon.echoBuffer
@@ -41,3 +148,4 @@ export const stripFormattingTags = addon.stripFormattingTags
 export const escapeXml = addon.escapeXml
 export const renderMultilineText = addon.renderMultilineText
 export const renderMultilineTextWithBackground = addon.renderMultilineTextWithBackground
+export const __nativeLoaded = nativeLoaded

--- a/crates/beautiful-mermaid-napi/src/lib.rs
+++ b/crates/beautiful-mermaid-napi/src/lib.rs
@@ -1,7 +1,73 @@
 use napi::bindgen_prelude::Uint8Array;
 use napi_derive::napi;
 
+use beautiful_mermaid_rs::utils::{
+    escape_xml as rs_escape_xml, normalize_br_tags as rs_normalize_br_tags,
+    render_multiline_text as rs_render_multiline_text,
+    render_multiline_text_with_background as rs_render_multiline_text_with_background,
+    strip_formatting_tags as rs_strip_formatting_tags,
+};
+
 #[napi]
 pub fn echo_buffer(input: Uint8Array) -> Uint8Array {
     input
+}
+
+#[napi(js_name = "normalizeBrTags")]
+pub fn normalize_br_tags(label: String) -> String {
+    rs_normalize_br_tags(&label)
+}
+
+#[napi(js_name = "stripFormattingTags")]
+pub fn strip_formatting_tags(text: String) -> String {
+    rs_strip_formatting_tags(&text)
+}
+
+#[napi(js_name = "escapeXml")]
+pub fn escape_xml(text: String) -> String {
+    rs_escape_xml(&text)
+}
+
+#[napi(js_name = "renderMultilineText")]
+pub fn render_multiline_text(
+    text: String,
+    cx: f64,
+    cy: f64,
+    font_size: f64,
+    attrs: String,
+    baseline_shift: Option<f64>,
+) -> String {
+    rs_render_multiline_text(
+        &text,
+        cx,
+        cy,
+        font_size,
+        &attrs,
+        baseline_shift.unwrap_or(0.35),
+    )
+}
+
+#[napi(js_name = "renderMultilineTextWithBackground")]
+pub fn render_multiline_text_with_background(
+    text: String,
+    cx: f64,
+    cy: f64,
+    text_width: f64,
+    text_height: f64,
+    font_size: f64,
+    padding: f64,
+    text_attrs: String,
+    bg_attrs: String,
+) -> String {
+    rs_render_multiline_text_with_background(
+        &text,
+        cx,
+        cy,
+        text_width,
+        text_height,
+        font_size,
+        padding,
+        &text_attrs,
+        &bg_attrs,
+    )
 }

--- a/crates/beautiful-mermaid-rs/src/lib.rs
+++ b/crates/beautiful-mermaid-rs/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod types;
+pub mod utils;
 
 pub use types::*;
+pub use utils::*;

--- a/crates/beautiful-mermaid-rs/src/utils.rs
+++ b/crates/beautiful-mermaid-rs/src/utils.rs
@@ -1,0 +1,520 @@
+const LINE_HEIGHT_RATIO: f64 = 1.3;
+const DEFAULT_BASELINE_SHIFT: f64 = 0.35;
+
+const STRIP_TAGS: [&str; 4] = ["sub", "sup", "small", "mark"];
+const FORMATTING_TAGS: [&str; 7] = ["b", "strong", "i", "em", "u", "s", "del"];
+
+#[derive(Clone, Copy, Default)]
+struct StyleState {
+    bold: bool,
+    italic: bool,
+    underline: bool,
+    strikethrough: bool,
+}
+
+#[derive(Clone)]
+struct StyledSegment {
+    text: String,
+    style: StyleState,
+}
+
+#[derive(Clone, Copy)]
+enum FormatTag {
+    Bold,
+    Italic,
+    Underline,
+    Strikethrough,
+}
+
+pub fn normalize_br_tags(label: &str) -> String {
+    let unquoted = strip_surrounding_quotes(label);
+    let with_breaks = replace_br_tags(unquoted).replace("\\n", "\n");
+    let stripped = remove_simple_tags(&with_breaks, &STRIP_TAGS);
+    let with_bold = replace_markdown_pair(&stripped, "**", "<b>", "</b>");
+    let with_italic = replace_markdown_italic(&with_bold);
+    replace_markdown_pair(&with_italic, "~~", "<s>", "</s>")
+}
+
+pub fn strip_formatting_tags(text: &str) -> String {
+    remove_simple_tags(text, &FORMATTING_TAGS)
+}
+
+pub fn escape_xml(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+pub fn render_multiline_text(
+    text: &str,
+    cx: f64,
+    cy: f64,
+    font_size: f64,
+    attrs: &str,
+    baseline_shift: f64,
+) -> String {
+    let lines: Vec<&str> = text.split('\n').collect();
+    if lines.len() == 1 {
+        let dy = font_size * baseline_shift;
+        return format!(
+            "<text x=\"{}\" y=\"{}\" {} dy=\"{}\">{}</text>",
+            cx,
+            cy,
+            attrs,
+            dy,
+            render_line_content(text)
+        );
+    }
+
+    let line_height = font_size * LINE_HEIGHT_RATIO;
+    let first_dy = -((lines.len() as f64 - 1.0) / 2.0) * line_height + font_size * baseline_shift;
+
+    let mut tspans = String::new();
+    for (index, line) in lines.iter().enumerate() {
+        let dy = if index == 0 { first_dy } else { line_height };
+        tspans.push_str(&format!(
+            "<tspan x=\"{}\" dy=\"{}\">{}</tspan>",
+            cx,
+            dy,
+            render_line_content(line)
+        ));
+    }
+
+    format!(
+        "<text x=\"{}\" y=\"{}\" {}>{}</text>",
+        cx, cy, attrs, tspans
+    )
+}
+
+pub fn render_multiline_text_with_background(
+    text: &str,
+    cx: f64,
+    cy: f64,
+    text_width: f64,
+    text_height: f64,
+    font_size: f64,
+    padding: f64,
+    text_attrs: &str,
+    bg_attrs: &str,
+) -> String {
+    let bg_width = text_width + padding * 2.0;
+    let bg_height = text_height + padding * 2.0;
+    let rect = format!(
+        "<rect x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\" {} />",
+        cx - bg_width / 2.0,
+        cy - bg_height / 2.0,
+        bg_width,
+        bg_height,
+        bg_attrs
+    );
+    let text_element =
+        render_multiline_text(text, cx, cy, font_size, text_attrs, DEFAULT_BASELINE_SHIFT);
+    format!("{}\n{}", rect, text_element)
+}
+
+fn strip_surrounding_quotes(input: &str) -> &str {
+    if input.starts_with('"') && input.ends_with('"') && input.len() >= 2 {
+        &input[1..input.len() - 1]
+    } else {
+        input
+    }
+}
+
+fn replace_br_tags(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut output = String::with_capacity(input.len());
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] == b'<' {
+            if let Some(end) = parse_br_tag(input, index) {
+                output.push('\n');
+                index = end;
+                continue;
+            }
+        }
+        let ch = next_char(input, index);
+        output.push(ch);
+        index += ch.len_utf8();
+    }
+
+    output
+}
+
+fn parse_br_tag(input: &str, start: usize) -> Option<usize> {
+    let bytes = input.as_bytes();
+    if *bytes.get(start)? != b'<' {
+        return None;
+    }
+
+    let mut index = start + 1;
+    if bytes
+        .get(index)
+        .copied()
+        .map(|byte| byte.to_ascii_lowercase())
+        != Some(b'b')
+    {
+        return None;
+    }
+    index += 1;
+    if bytes
+        .get(index)
+        .copied()
+        .map(|byte| byte.to_ascii_lowercase())
+        != Some(b'r')
+    {
+        return None;
+    }
+    index += 1;
+
+    while bytes
+        .get(index)
+        .is_some_and(|byte| byte.is_ascii_whitespace())
+    {
+        index += 1;
+    }
+    if bytes.get(index) == Some(&b'/') {
+        index += 1;
+        while bytes
+            .get(index)
+            .is_some_and(|byte| byte.is_ascii_whitespace())
+        {
+            index += 1;
+        }
+    }
+
+    if bytes.get(index) != Some(&b'>') {
+        return None;
+    }
+    Some(index + 1)
+}
+
+fn remove_simple_tags(input: &str, tags: &[&str]) -> String {
+    let bytes = input.as_bytes();
+    let mut output = String::with_capacity(input.len());
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] == b'<' {
+            if let Some((end, _, _)) = parse_simple_tag(input, index, tags) {
+                index = end;
+                continue;
+            }
+        }
+        let ch = next_char(input, index);
+        output.push(ch);
+        index += ch.len_utf8();
+    }
+
+    output
+}
+
+fn parse_simple_tag(input: &str, start: usize, tags: &[&str]) -> Option<(usize, usize, bool)> {
+    let bytes = input.as_bytes();
+    if *bytes.get(start)? != b'<' {
+        return None;
+    }
+
+    let mut index = start + 1;
+    let mut is_closing = false;
+    if bytes.get(index) == Some(&b'/') {
+        is_closing = true;
+        index += 1;
+    }
+
+    let name_start = index;
+    while bytes
+        .get(index)
+        .is_some_and(|byte| byte.is_ascii_alphabetic())
+    {
+        index += 1;
+    }
+    if index == name_start {
+        return None;
+    }
+
+    let tag_name = &input[name_start..index];
+    let tag_index = tags
+        .iter()
+        .position(|tag| tag_name.eq_ignore_ascii_case(tag))?;
+
+    while bytes
+        .get(index)
+        .is_some_and(|byte| byte.is_ascii_whitespace())
+    {
+        index += 1;
+    }
+    if bytes.get(index) != Some(&b'>') {
+        return None;
+    }
+
+    Some((index + 1, tag_index, is_closing))
+}
+
+fn replace_markdown_pair(input: &str, marker: &str, open_tag: &str, close_tag: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut cursor = 0;
+
+    loop {
+        let Some(rel_start) = input[cursor..].find(marker) else {
+            output.push_str(&input[cursor..]);
+            break;
+        };
+        let start = cursor + rel_start;
+        let content_start = start + marker.len();
+
+        let Some(rel_end) = input[content_start..].find(marker) else {
+            output.push_str(&input[cursor..]);
+            break;
+        };
+        let end = content_start + rel_end;
+
+        if end == content_start {
+            output.push_str(&input[cursor..content_start]);
+            cursor = content_start;
+            continue;
+        }
+
+        output.push_str(&input[cursor..start]);
+        output.push_str(open_tag);
+        output.push_str(&input[content_start..end]);
+        output.push_str(close_tag);
+        cursor = end + marker.len();
+    }
+
+    output
+}
+
+fn replace_markdown_italic(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut output = String::with_capacity(input.len());
+    let mut cursor = 0;
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] != b'*' {
+            index += 1;
+            continue;
+        }
+
+        if index > 0 && bytes[index - 1] == b'*' {
+            index += 1;
+            continue;
+        }
+        if index + 1 >= bytes.len() || bytes[index + 1] == b'*' {
+            index += 1;
+            continue;
+        }
+
+        let mut end = index + 1;
+        while end < bytes.len() && bytes[end] != b'*' {
+            end += 1;
+        }
+        if end >= bytes.len() {
+            break;
+        }
+        if end + 1 < bytes.len() && bytes[end + 1] == b'*' {
+            index += 1;
+            continue;
+        }
+
+        let inner = &input[index + 1..end];
+        if !is_valid_italic_inner(inner) {
+            index += 1;
+            continue;
+        }
+
+        output.push_str(&input[cursor..index]);
+        output.push_str("<i>");
+        output.push_str(inner);
+        output.push_str("</i>");
+        cursor = end + 1;
+        index = end + 1;
+    }
+
+    output.push_str(&input[cursor..]);
+    output
+}
+
+fn is_valid_italic_inner(inner: &str) -> bool {
+    if inner.is_empty() || inner.contains('*') {
+        return false;
+    }
+    let mut chars = inner.chars();
+    let first = chars.next().expect("inner is not empty");
+    let last = inner.chars().next_back().expect("inner is not empty");
+    !first.is_whitespace() && first != '*' && !last.is_whitespace() && last != '*'
+}
+
+fn contains_format_tag(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'<' && parse_format_tag(line, index).is_some() {
+            return true;
+        }
+        let ch = next_char(line, index);
+        index += ch.len_utf8();
+    }
+    false
+}
+
+fn parse_format_tag(input: &str, start: usize) -> Option<(usize, FormatTag, bool)> {
+    let (end, tag_index, is_closing) = parse_simple_tag(input, start, &FORMATTING_TAGS)?;
+    let kind = match tag_index {
+        0 | 1 => FormatTag::Bold,
+        2 | 3 => FormatTag::Italic,
+        4 => FormatTag::Underline,
+        5 | 6 => FormatTag::Strikethrough,
+        _ => return None,
+    };
+    Some((end, kind, is_closing))
+}
+
+fn parse_inline_formatting(line: &str) -> Vec<StyledSegment> {
+    let bytes = line.as_bytes();
+    let mut segments = Vec::new();
+    let mut style = StyleState::default();
+    let mut last_index = 0;
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] == b'<' {
+            if let Some((end, tag, is_closing)) = parse_format_tag(line, index) {
+                if index > last_index {
+                    segments.push(StyledSegment {
+                        text: line[last_index..index].to_string(),
+                        style,
+                    });
+                }
+                match tag {
+                    FormatTag::Bold => style.bold = !is_closing,
+                    FormatTag::Italic => style.italic = !is_closing,
+                    FormatTag::Underline => style.underline = !is_closing,
+                    FormatTag::Strikethrough => style.strikethrough = !is_closing,
+                }
+                last_index = end;
+                index = end;
+                continue;
+            }
+        }
+        let ch = next_char(line, index);
+        index += ch.len_utf8();
+    }
+
+    if last_index < line.len() {
+        segments.push(StyledSegment {
+            text: line[last_index..].to_string(),
+            style,
+        });
+    }
+
+    segments
+}
+
+fn render_line_content(line: &str) -> String {
+    if !contains_format_tag(line) {
+        return escape_xml(line);
+    }
+
+    let segments = parse_inline_formatting(line);
+    if segments.is_empty() {
+        return String::new();
+    }
+
+    let all_plain = segments.iter().all(|segment| {
+        !segment.style.bold
+            && !segment.style.italic
+            && !segment.style.underline
+            && !segment.style.strikethrough
+    });
+
+    if all_plain {
+        return segments
+            .iter()
+            .map(|segment| escape_xml(&segment.text))
+            .collect::<Vec<String>>()
+            .join("");
+    }
+
+    let mut output = String::new();
+    for segment in &segments {
+        let escaped = escape_xml(&segment.text);
+        if !segment.style.bold
+            && !segment.style.italic
+            && !segment.style.underline
+            && !segment.style.strikethrough
+        {
+            output.push_str(&escaped);
+            continue;
+        }
+
+        let mut attrs = Vec::new();
+        if segment.style.bold {
+            attrs.push(String::from("font-weight=\"bold\""));
+        }
+        if segment.style.italic {
+            attrs.push(String::from("font-style=\"italic\""));
+        }
+        let mut decorations = Vec::new();
+        if segment.style.underline {
+            decorations.push("underline");
+        }
+        if segment.style.strikethrough {
+            decorations.push("line-through");
+        }
+        if !decorations.is_empty() {
+            attrs.push(format!("text-decoration=\"{}\"", decorations.join(" ")));
+        }
+        output.push_str(&format!("<tspan {}>{}</tspan>", attrs.join(" "), escaped));
+    }
+
+    output
+}
+
+fn next_char(input: &str, index: usize) -> char {
+    input[index..]
+        .chars()
+        .next()
+        .expect("index is valid UTF-8 boundary")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_br_tags_handles_markdown_and_html() {
+        assert_eq!(normalize_br_tags("a<br>b"), "a\nb");
+        assert_eq!(normalize_br_tags("a\\nb"), "a\nb");
+        assert_eq!(normalize_br_tags("**text**"), "<b>text</b>");
+        assert_eq!(normalize_br_tags("*a* 与 * a *"), "<i>a</i> 与 * a *");
+        assert_eq!(normalize_br_tags("~~text~~"), "<s>text</s>");
+        assert_eq!(normalize_br_tags("H<sub>2</sub>O"), "H2O");
+    }
+
+    #[test]
+    fn strip_and_escape_follow_ts_behavior() {
+        assert_eq!(
+            strip_formatting_tags("<b>bold</b> <i>italic</i>"),
+            "bold italic"
+        );
+        assert_eq!(escape_xml("& < > \" '"), "&amp; &lt; &gt; &quot; &#39;");
+    }
+
+    #[test]
+    fn render_multiline_text_matches_expected_dy() {
+        let rendered = render_multiline_text(
+            "line1\nline2\nline3",
+            100.0,
+            80.0,
+            16.0,
+            "text-anchor=\"middle\"",
+            0.35,
+        );
+        assert!(rendered.contains("dy=\"-15.200000000000001\""));
+        assert_eq!(rendered.matches("dy=\"20.8\"").count(), 2);
+    }
+}

--- a/crates/beautiful-mermaid-rs/src/utils.rs
+++ b/crates/beautiful-mermaid-rs/src/utils.rs
@@ -115,8 +115,12 @@ pub fn render_multiline_text_with_background(
 }
 
 fn strip_surrounding_quotes(input: &str) -> &str {
-    if input.starts_with('"') && input.ends_with('"') && input.len() >= 2 {
-        &input[1..input.len() - 1]
+    if input.starts_with('"') && input.ends_with('"') {
+        if input.len() <= 1 {
+            ""
+        } else {
+            &input[1..input.len() - 1]
+        }
     } else {
         input
     }
@@ -489,6 +493,7 @@ mod tests {
     fn normalize_br_tags_handles_markdown_and_html() {
         assert_eq!(normalize_br_tags("a<br>b"), "a\nb");
         assert_eq!(normalize_br_tags("a\\nb"), "a\nb");
+        assert_eq!(normalize_br_tags("\""), "");
         assert_eq!(normalize_br_tags("**text**"), "<b>text</b>");
         assert_eq!(normalize_br_tags("*a* 与 * a *"), "<i>a</i> 与 * a *");
         assert_eq!(normalize_br_tags("~~text~~"), "<s>text</s>");

--- a/src/__tests__/multiline-utils.unit.test.ts
+++ b/src/__tests__/multiline-utils.unit.test.ts
@@ -11,6 +11,7 @@ import {
 const require = createRequire(import.meta.url)
 
 type RustAddon = {
+  __nativeLoaded: boolean
   normalizeBrTags(label: string): string
   stripFormattingTags(text: string): string
   escapeXml(text: string): string
@@ -60,6 +61,12 @@ function runTs<T>(fn: () => T): T {
 }
 
 describe('multiline utils rust parity', () => {
+  it('requires native addon when rust path is enforced', () => {
+    if (process.env.BEAUTIFUL_MERMAID_NAPI_REQUIRE_NATIVE === '1') {
+      expect(rustAddon.__nativeLoaded).toBe(true)
+    }
+  })
+
   it('normalizes br variants to newline', () => {
     const inputs = ['a<br>b', 'a<br/>b', 'a<br />b', 'a<BR>b']
     for (const input of inputs) {
@@ -75,6 +82,14 @@ describe('multiline utils rust parity', () => {
     const ts = runTs(() => normalizeBrTags(input))
     const rust = rustAddon.normalizeBrTags(input)
     expect(ts).toBe('a\nb')
+    expect(rust).toBe(ts)
+  })
+
+  it('strips surrounding quote for single quote char input', () => {
+    const input = '"'
+    const ts = runTs(() => normalizeBrTags(input))
+    const rust = rustAddon.normalizeBrTags(input)
+    expect(ts).toBe('')
     expect(rust).toBe(ts)
   })
 

--- a/src/__tests__/multiline-utils.unit.test.ts
+++ b/src/__tests__/multiline-utils.unit.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'bun:test'
+import { createRequire } from 'node:module'
+import {
+  normalizeBrTags,
+  stripFormattingTags,
+  escapeXml,
+  renderMultilineText,
+  renderMultilineTextWithBackground,
+} from '../multiline-utils.ts'
+
+const require = createRequire(import.meta.url)
+
+type RustAddon = {
+  normalizeBrTags(label: string): string
+  stripFormattingTags(text: string): string
+  escapeXml(text: string): string
+  renderMultilineText(
+    text: string,
+    cx: number,
+    cy: number,
+    fontSize: number,
+    attrs: string,
+    baselineShift?: number
+  ): string
+  renderMultilineTextWithBackground(
+    text: string,
+    cx: number,
+    cy: number,
+    textWidth: number,
+    textHeight: number,
+    fontSize: number,
+    padding: number,
+    textAttrs: string,
+    bgAttrs: string
+  ): string
+}
+
+const rustAddon = require('../../crates/beautiful-mermaid-napi/index.js') as RustAddon
+
+function withRustFlag<T>(flag: string | undefined, fn: () => T): T {
+  const prev = process.env.BEAUTIFUL_MERMAID_USE_RUST
+  if (flag === undefined) {
+    delete process.env.BEAUTIFUL_MERMAID_USE_RUST
+  } else {
+    process.env.BEAUTIFUL_MERMAID_USE_RUST = flag
+  }
+  try {
+    return fn()
+  } finally {
+    if (prev === undefined) {
+      delete process.env.BEAUTIFUL_MERMAID_USE_RUST
+    } else {
+      process.env.BEAUTIFUL_MERMAID_USE_RUST = prev
+    }
+  }
+}
+
+function runTs<T>(fn: () => T): T {
+  return withRustFlag(undefined, fn)
+}
+
+describe('multiline utils rust parity', () => {
+  it('normalizes br variants to newline', () => {
+    const inputs = ['a<br>b', 'a<br/>b', 'a<br />b', 'a<BR>b']
+    for (const input of inputs) {
+      const ts = runTs(() => normalizeBrTags(input))
+      const rust = rustAddon.normalizeBrTags(input)
+      expect(ts).toBe('a\nb')
+      expect(rust).toBe(ts)
+    }
+  })
+
+  it('converts literal \\n to newline', () => {
+    const input = 'a\\nb'
+    const ts = runTs(() => normalizeBrTags(input))
+    const rust = rustAddon.normalizeBrTags(input)
+    expect(ts).toBe('a\nb')
+    expect(rust).toBe(ts)
+  })
+
+  it('converts markdown bold', () => {
+    const input = '**text**'
+    const ts = runTs(() => normalizeBrTags(input))
+    const rust = rustAddon.normalizeBrTags(input)
+    expect(ts).toBe('<b>text</b>')
+    expect(rust).toBe(ts)
+  })
+
+  it('handles markdown italic boundary', () => {
+    const input = '*a* 与 * a *'
+    const ts = runTs(() => normalizeBrTags(input))
+    const rust = rustAddon.normalizeBrTags(input)
+    expect(ts).toBe('<i>a</i> 与 * a *')
+    expect(rust).toBe(ts)
+  })
+
+  it('converts markdown strike', () => {
+    const input = '~~text~~'
+    const ts = runTs(() => normalizeBrTags(input))
+    const rust = rustAddon.normalizeBrTags(input)
+    expect(ts).toBe('<s>text</s>')
+    expect(rust).toBe(ts)
+  })
+
+  it('strips special sub/sup tags', () => {
+    const input = 'H<sub>2</sub>O 与 x<sup>2</sup>'
+    const ts = runTs(() => normalizeBrTags(input))
+    const rust = rustAddon.normalizeBrTags(input)
+    expect(ts).toBe('H2O 与 x2')
+    expect(rust).toBe(ts)
+  })
+
+  it('escapes xml characters', () => {
+    const input = '& < > " \''
+    const ts = runTs(() => escapeXml(input))
+    const rust = rustAddon.escapeXml(input)
+    expect(ts).toBe('&amp; &lt; &gt; &quot; &#39;')
+    expect(rust).toBe(ts)
+  })
+
+  it('renders nested formatting tags consistently', () => {
+    const input = '<b><i>text</i></b>'
+    const attrs = 'text-anchor="middle"'
+    const ts = runTs(() => renderMultilineText(input, 120, 80, 16, attrs))
+    const rust = rustAddon.renderMultilineText(input, 120, 80, 16, attrs, 0.35)
+    expect(rust).toBe(ts)
+    expect(ts).toContain('font-weight="bold"')
+    expect(ts).toContain('font-style="italic"')
+  })
+
+  it('keeps multiline dy calculation equal', () => {
+    const input = 'line1\nline2\nline3'
+    const attrs = 'text-anchor="middle"'
+    const ts = runTs(() => renderMultilineText(input, 120, 80, 16, attrs))
+    const rust = rustAddon.renderMultilineText(input, 120, 80, 16, attrs, 0.35)
+    expect(rust).toBe(ts)
+    expect(ts).toContain('dy="-15.200000000000001"')
+    expect(ts.match(/dy="20.8"/g)).toHaveLength(2)
+  })
+
+  it('keeps background rendering output equal', () => {
+    const input = 'line1\nline2'
+    const textAttrs = 'text-anchor="middle" fill="var(--_text)"'
+    const bgAttrs = 'fill="var(--_bg)"'
+    const ts = runTs(() =>
+      renderMultilineTextWithBackground(
+        input,
+        100,
+        80,
+        120,
+        42,
+        16,
+        6,
+        textAttrs,
+        bgAttrs
+      )
+    )
+    const rust = rustAddon.renderMultilineTextWithBackground(
+      input,
+      100,
+      80,
+      120,
+      42,
+      16,
+      6,
+      textAttrs,
+      bgAttrs
+    )
+    expect(rust).toBe(ts)
+  })
+
+  it('uses rust adapter when BEAUTIFUL_MERMAID_USE_RUST=1', () => {
+    const input = '**text**'
+    const expected = rustAddon.normalizeBrTags(input)
+    const actual = withRustFlag('1', () => normalizeBrTags(input))
+    expect(actual).toBe(expected)
+  })
+
+  it('stripFormattingTags stays equal between ts and rust', () => {
+    const input = '<b>bold</b> and <i>italic</i>'
+    const ts = runTs(() => stripFormattingTags(input))
+    const rust = rustAddon.stripFormattingTags(input)
+    expect(ts).toBe('bold and italic')
+    expect(rust).toBe(ts)
+  })
+})

--- a/src/__tests__/multiline-utils.unit.test.ts
+++ b/src/__tests__/multiline-utils.unit.test.ts
@@ -77,6 +77,14 @@ describe('multiline utils rust parity', () => {
     }
   })
 
+  it('keeps invalid br form with slash-space unchanged', () => {
+    const input = 'a<br/ >b'
+    const ts = runTs(() => normalizeBrTags(input))
+    const rust = rustAddon.normalizeBrTags(input)
+    expect(ts).toBe('a<br/ >b')
+    expect(rust).toBe(ts)
+  })
+
   it('converts literal \\n to newline', () => {
     const input = 'a\\nb'
     const ts = runTs(() => normalizeBrTags(input))
@@ -99,6 +107,19 @@ describe('multiline utils rust parity', () => {
     const rust = rustAddon.normalizeBrTags(input)
     expect(ts).toBe('<b>text</b>')
     expect(rust).toBe(ts)
+  })
+
+  it('matches overlapping markdown pair behavior for bold/strike', () => {
+    const boldInput = '*****'
+    const strikeInput = '~~~~~'
+    const tsBold = runTs(() => normalizeBrTags(boldInput))
+    const rustBold = rustAddon.normalizeBrTags(boldInput)
+    const tsStrike = runTs(() => normalizeBrTags(strikeInput))
+    const rustStrike = rustAddon.normalizeBrTags(strikeInput)
+    expect(tsBold).toBe('<b>*</b>')
+    expect(rustBold).toBe(tsBold)
+    expect(tsStrike).toBe('<s>~</s>')
+    expect(rustStrike).toBe(tsStrike)
   })
 
   it('handles markdown italic boundary', () => {

--- a/src/__tests__/multiline-utils.unit.test.ts
+++ b/src/__tests__/multiline-utils.unit.test.ts
@@ -109,6 +109,14 @@ describe('multiline utils rust parity', () => {
     expect(rust).toBe(ts)
   })
 
+  it('does not apply bold/strike across line breaks', () => {
+    const input = '**a<br>b** and ~~x<br>y~~'
+    const ts = runTs(() => normalizeBrTags(input))
+    const rust = rustAddon.normalizeBrTags(input)
+    expect(ts).toBe('**a\nb** and ~~x\ny~~')
+    expect(rust).toBe(ts)
+  })
+
   it('matches overlapping markdown pair behavior for bold/strike', () => {
     const boldInput = '*****'
     const strikeInput = '~~~~~'

--- a/src/__tests__/multiline-utils.unit.test.ts
+++ b/src/__tests__/multiline-utils.unit.test.ts
@@ -85,6 +85,27 @@ describe('multiline utils rust parity', () => {
     expect(rust).toBe(ts)
   })
 
+  it('handles unicode whitespace in tags same as ts', () => {
+    const brInput = 'a<br\u00a0>b'
+    const subInput = 'H<sub\u00a0>2</sub\u00a0>O'
+    const boldInput = '<b\u00a0>bold</b\u00a0>'
+
+    const tsBr = runTs(() => normalizeBrTags(brInput))
+    const rustBr = rustAddon.normalizeBrTags(brInput)
+    expect(tsBr).toBe('a\nb')
+    expect(rustBr).toBe(tsBr)
+
+    const tsSub = runTs(() => normalizeBrTags(subInput))
+    const rustSub = rustAddon.normalizeBrTags(subInput)
+    expect(tsSub).toBe('H2O')
+    expect(rustSub).toBe(tsSub)
+
+    const tsBold = runTs(() => stripFormattingTags(boldInput))
+    const rustBold = rustAddon.stripFormattingTags(boldInput)
+    expect(tsBold).toBe('bold')
+    expect(rustBold).toBe(tsBold)
+  })
+
   it('converts literal \\n to newline', () => {
     const input = 'a\\nb'
     const ts = runTs(() => normalizeBrTags(input))

--- a/src/__tests__/napi-smoke.test.ts
+++ b/src/__tests__/napi-smoke.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'bun:test'
-import { echoBuffer } from '../../crates/beautiful-mermaid-napi/index.js'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const { echoBuffer } = require('../../crates/beautiful-mermaid-napi/index.js') as {
+  echoBuffer(input: Uint8Array): Uint8Array
+}
 
 describe('napi smoke', () => {
   it('echoBuffer returns same data', () => {

--- a/src/multiline-utils.ts
+++ b/src/multiline-utils.ts
@@ -6,21 +6,88 @@
 // Used across all diagram types (flowcharts, state, sequence, class, ER).
 // ============================================================================
 
+import { createRequire } from 'node:module'
 import { LINE_HEIGHT_RATIO } from './text-metrics.ts'
+
+const require = createRequire(import.meta.url)
+
+interface MultilineRustAddon {
+  normalizeBrTags(label: string): string
+  stripFormattingTags(text: string): string
+  escapeXml(text: string): string
+  renderMultilineText(
+    text: string,
+    cx: number,
+    cy: number,
+    fontSize: number,
+    attrs: string,
+    baselineShift?: number
+  ): string
+  renderMultilineTextWithBackground(
+    text: string,
+    cx: number,
+    cy: number,
+    textWidth: number,
+    textHeight: number,
+    fontSize: number,
+    padding: number,
+    textAttrs: string,
+    bgAttrs: string
+  ): string
+}
+
+let rustAddonCache: MultilineRustAddon | null | undefined
+
+function isRustMultilineEnabled(): boolean {
+  const flag = typeof process !== 'undefined' ? process.env?.BEAUTIFUL_MERMAID_USE_RUST : undefined
+  if (!flag) return false
+  const normalized = flag.toLowerCase()
+  return normalized === '1' || normalized === 'true'
+}
+
+function loadRustAddon(): MultilineRustAddon | null {
+  if (rustAddonCache !== undefined) return rustAddonCache
+  try {
+    const addon = require('../crates/beautiful-mermaid-napi/index.js') as Partial<MultilineRustAddon>
+    if (
+      typeof addon.normalizeBrTags === 'function' &&
+      typeof addon.stripFormattingTags === 'function' &&
+      typeof addon.escapeXml === 'function' &&
+      typeof addon.renderMultilineText === 'function' &&
+      typeof addon.renderMultilineTextWithBackground === 'function'
+    ) {
+      rustAddonCache = addon as MultilineRustAddon
+    } else {
+      rustAddonCache = null
+    }
+  } catch {
+    rustAddonCache = null
+  }
+  return rustAddonCache
+}
+
+function tryRunRust<T>(fn: (addon: MultilineRustAddon) => T): T | undefined {
+  if (!isRustMultilineEnabled()) return undefined
+  const addon = loadRustAddon()
+  if (!addon) return undefined
+  try {
+    return fn(addon)
+  } catch {
+    return undefined
+  }
+}
 
 /**
  * Normalize label text: strip surrounding quotes, convert <br> tags and
  * literal \n sequences to newline characters. Strips unsupported HTML tags
  * but preserves formatting tags (<b>, <i>, <u>, <s>) for SVG rendering.
  */
-export function normalizeBrTags(label: string): string {
-  // Strip surrounding double quotes (Mermaid uses them for special chars in labels)
+function normalizeBrTagsTs(label: string): string {
   const unquoted = label.startsWith('"') && label.endsWith('"') ? label.slice(1, -1) : label
   return unquoted
     .replace(/<br\s*\/?>/gi, '\n')
     .replace(/\\n/g, '\n')
     .replace(/<\/?(?:sub|sup|small|mark)\s*>/gi, '')
-    // Markdown formatting → HTML tags (order matters: ** before *)
     .replace(/\*\*(.+?)\*\*/g, '<b>$1</b>')
     .replace(/(?<!\*)\*([^\s*](?:[^*]*[^\s*])?)\*(?!\*)/g, '<i>$1</i>')
     .replace(/~~(.+?)~~/g, '<s>$1</s>')
@@ -30,14 +97,14 @@ export function normalizeBrTags(label: string): string {
  * Strip all inline formatting tags from text, keeping only plain text.
  * Used for text measurement where tag characters shouldn't affect width.
  */
-export function stripFormattingTags(text: string): string {
+function stripFormattingTagsTs(text: string): string {
   return text.replace(/<\/?(?:b|strong|i|em|u|s|del)\s*>/gi, '')
 }
 
 /**
  * Escape special XML characters in text content.
  */
-export function escapeXml(text: string): string {
+function escapeXmlTs(text: string): string {
   return text
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
@@ -58,38 +125,29 @@ interface StyledSegment {
   strikethrough: boolean
 }
 
-/** Regex to match opening/closing formatting tags */
 const FORMAT_TAG_REGEX = /<(\/)?(?:(b|strong)|(i|em)|(u)|(s|del))\s*>/gi
+const HAS_FORMAT_TAGS = /<\/?(?:b|strong|i|em|u|s|del)\s*>/i
 
-/**
- * Parse a line of text into styled segments based on inline formatting tags.
- * Supports nesting: `<b>bold <i>both</i> bold</b>`.
- */
 function parseInlineFormatting(line: string): StyledSegment[] {
   const segments: StyledSegment[] = []
   let bold = false, italic = false, underline = false, strikethrough = false
   let lastIndex = 0
 
-  // Reset lastIndex for global regex
   FORMAT_TAG_REGEX.lastIndex = 0
-
   let match: RegExpExecArray | null
   while ((match = FORMAT_TAG_REGEX.exec(line)) !== null) {
-    // Capture text before this tag
     if (match.index > lastIndex) {
       segments.push({ text: line.slice(lastIndex, match.index), bold, italic, underline, strikethrough })
     }
     lastIndex = match.index + match[0].length
 
     const isClosing = Boolean(match[1])
-    // match[2] = b|strong, match[3] = i|em, match[4] = u, match[5] = s|del
     if (match[2]) bold = !isClosing
     else if (match[3]) italic = !isClosing
     else if (match[4]) underline = !isClosing
     else if (match[5]) strikethrough = !isClosing
   }
 
-  // Remaining text after last tag
   if (lastIndex < line.length) {
     segments.push({ text: line.slice(lastIndex), bold, italic, underline, strikethrough })
   }
@@ -97,32 +155,22 @@ function parseInlineFormatting(line: string): StyledSegment[] {
   return segments
 }
 
-/** Check if a line contains any formatting tags */
-const HAS_FORMAT_TAGS = /<\/?(?:b|strong|i|em|u|s|del)\s*>/i
-
-/**
- * Render a line's content as SVG, with inline formatting applied as tspan attributes.
- * Returns raw SVG content (no wrapping tspan — caller provides positioning).
- */
-function renderLineContent(line: string): string {
-  // Fast path: no formatting tags
-  if (!HAS_FORMAT_TAGS.test(line)) return escapeXml(line)
+function renderLineContentTs(line: string): string {
+  if (!HAS_FORMAT_TAGS.test(line)) return escapeXmlTs(line)
 
   const segments = parseInlineFormatting(line)
   if (segments.length === 0) return ''
 
-  // If all segments are unstyled, just escape
   const allPlain = segments.every(s => !s.bold && !s.italic && !s.underline && !s.strikethrough)
-  if (allPlain) return segments.map(s => escapeXml(s.text)).join('')
+  if (allPlain) return segments.map(s => escapeXmlTs(s.text)).join('')
 
   return segments.map(seg => {
-    const escaped = escapeXml(seg.text)
+    const escaped = escapeXmlTs(seg.text)
     if (!seg.bold && !seg.italic && !seg.underline && !seg.strikethrough) return escaped
 
     const attrs: string[] = []
     if (seg.bold) attrs.push('font-weight="bold"')
     if (seg.italic) attrs.push('font-style="italic"')
-    // SVG text-decoration can combine values
     const deco: string[] = []
     if (seg.underline) deco.push('underline')
     if (seg.strikethrough) deco.push('line-through')
@@ -132,26 +180,7 @@ function renderLineContent(line: string): string {
   }).join('')
 }
 
-// ============================================================================
-// Multi-line text rendering
-// ============================================================================
-
-/**
- * Render a multi-line text element with proper vertical centering.
- *
- * For single-line text, returns a simple <text> element.
- * For multi-line text (containing \n), returns <text> with <tspan> children.
- * Inline formatting tags (<b>, <i>, <u>, <s>) are rendered as SVG attributes.
- *
- * @param text - The text to render (may contain \n and formatting tags)
- * @param cx - Center x coordinate
- * @param cy - Center y coordinate
- * @param fontSize - Font size in pixels
- * @param attrs - Additional SVG attributes (e.g., 'text-anchor="middle" fill="var(--_text)"')
- * @param baselineShift - Baseline shift for vertical alignment (default 0.35)
- * @returns SVG text element string
- */
-export function renderMultilineText(
+function renderMultilineTextTs(
   text: string,
   cx: number,
   cy: number,
@@ -161,42 +190,23 @@ export function renderMultilineText(
 ): string {
   const lines = text.split('\n')
 
-  // Single line — simple text element
   if (lines.length === 1) {
     const dy = fontSize * baselineShift
-    return `<text x="${cx}" y="${cy}" ${attrs} dy="${dy}">${renderLineContent(text)}</text>`
+    return `<text x="${cx}" y="${cy}" ${attrs} dy="${dy}">${renderLineContentTs(text)}</text>`
   }
 
-  // Multi-line — use tspan elements with vertical centering
   const lineHeight = fontSize * LINE_HEIGHT_RATIO
-  // First line dy: shift up by (n-1)/2 line heights, then add baseline shift
   const firstDy = -((lines.length - 1) / 2) * lineHeight + fontSize * baselineShift
 
   const tspans = lines.map((line, i) => {
     const dy = i === 0 ? firstDy : lineHeight
-    return `<tspan x="${cx}" dy="${dy}">${renderLineContent(line)}</tspan>`
+    return `<tspan x="${cx}" dy="${dy}">${renderLineContentTs(line)}</tspan>`
   }).join('')
 
   return `<text x="${cx}" y="${cy}" ${attrs}>${tspans}</text>`
 }
 
-/**
- * Render a multi-line text element with a background rectangle (pill).
- *
- * Used for edge labels that need a background for readability.
- *
- * @param text - The text to render (may contain \n)
- * @param cx - Center x coordinate
- * @param cy - Center y coordinate
- * @param textWidth - Pre-calculated text width (max line width)
- * @param textHeight - Pre-calculated text height (lines × lineHeight)
- * @param fontSize - Font size in pixels
- * @param padding - Padding around text
- * @param textAttrs - SVG attributes for the text element
- * @param bgAttrs - SVG attributes for the background rect
- * @returns SVG elements string (rect + text)
- */
-export function renderMultilineTextWithBackground(
+function renderMultilineTextWithBackgroundTs(
   text: string,
   cx: number,
   cy: number,
@@ -213,7 +223,53 @@ export function renderMultilineTextWithBackground(
   const rect = `<rect x="${cx - bgWidth / 2}" y="${cy - bgHeight / 2}" ` +
     `width="${bgWidth}" height="${bgHeight}" ${bgAttrs} />`
 
-  const textEl = renderMultilineText(text, cx, cy, fontSize, textAttrs)
-
+  const textEl = renderMultilineTextTs(text, cx, cy, fontSize, textAttrs)
   return `${rect}\n${textEl}`
+}
+
+export function normalizeBrTags(label: string): string {
+  const fromRust = tryRunRust(addon => addon.normalizeBrTags(label))
+  return fromRust ?? normalizeBrTagsTs(label)
+}
+
+export function stripFormattingTags(text: string): string {
+  const fromRust = tryRunRust(addon => addon.stripFormattingTags(text))
+  return fromRust ?? stripFormattingTagsTs(text)
+}
+
+export function escapeXml(text: string): string {
+  const fromRust = tryRunRust(addon => addon.escapeXml(text))
+  return fromRust ?? escapeXmlTs(text)
+}
+
+export function renderMultilineText(
+  text: string,
+  cx: number,
+  cy: number,
+  fontSize: number,
+  attrs: string,
+  baselineShift: number = 0.35
+): string {
+  const fromRust = tryRunRust(addon => addon.renderMultilineText(text, cx, cy, fontSize, attrs, baselineShift))
+  return fromRust ?? renderMultilineTextTs(text, cx, cy, fontSize, attrs, baselineShift)
+}
+
+export function renderMultilineTextWithBackground(
+  text: string,
+  cx: number,
+  cy: number,
+  textWidth: number,
+  textHeight: number,
+  fontSize: number,
+  padding: number,
+  textAttrs: string,
+  bgAttrs: string
+): string {
+  const fromRust = tryRunRust(addon =>
+    addon.renderMultilineTextWithBackground(
+      text, cx, cy, textWidth, textHeight, fontSize, padding, textAttrs, bgAttrs
+    ))
+  return fromRust ?? renderMultilineTextWithBackgroundTs(
+    text, cx, cy, textWidth, textHeight, fontSize, padding, textAttrs, bgAttrs
+  )
 }

--- a/src/multiline-utils.ts
+++ b/src/multiline-utils.ts
@@ -12,6 +12,7 @@ import { LINE_HEIGHT_RATIO } from './text-metrics.ts'
 const require = createRequire(import.meta.url)
 
 interface MultilineRustAddon {
+  __nativeLoaded: boolean
   normalizeBrTags(label: string): string
   stripFormattingTags(text: string): string
   escapeXml(text: string): string
@@ -50,6 +51,7 @@ function loadRustAddon(): MultilineRustAddon | null {
   try {
     const addon = require('../crates/beautiful-mermaid-napi/index.js') as Partial<MultilineRustAddon>
     if (
+      addon.__nativeLoaded === true &&
       typeof addon.normalizeBrTags === 'function' &&
       typeof addon.stripFormattingTags === 'function' &&
       typeof addon.escapeXml === 'function' &&


### PR DESCRIPTION
Closes #6

## Summary

## ✅ 最终方案：sub(#4) multiline-utils Rust 等价迁移与灰度切换方案

### 实现方案

前置条件：依赖 #5 已提供 Rust crate 骨架与 NAPI 构建链路。实施分 5 步：1) 行为基线冻结：以当前 src/multiline-utils.ts 为唯一真值，整理 golden cases（<br> 变体、markdown 转标签、嵌套格式、XML 转义、多行 dy）。2) Rust 等价实现：在 crates/beautiful-mermaid-rs/src/utils.rs 逐一实现 normalize_br_tags、strip_formatting_tags、escape_xml、render_multiline_text、render_multiline_text_with_background，并补 parse/render line 内容逻辑；对 italic 规则不引入 fancy-regex，采用“先 bold 再 italic”的顺序与手写扫描兜底，确保与 TS 语义一致。3) NAPI 暴露：在 crates/beautiful-mermaid-napi/src/lib.rs 导出对应 Rust 函数，在 crates/beautiful-mermaid-napi/index.js 暴露 JS API。4) TS 适配层：保持 src/multiline-utils.ts 导出签名不变，默认走 TS 实现；当 BEAUTIFUL_MERMAID_USE_RUST=1 时走 Rust，实现异常时自动回退 TS（不中断渲染）。5) 验证与上线：新增 Rust↔TS 对照单测，跑现有 multiline-labels 集成测试；CI 同时验证默认路径与 Rust 开关路径，全部通过后再评估是否切默认 Rust。

### 文件变更

| 路径 | 操作 | 描述 |
|------|------|------|
| `src/multiline-utils.ts` | modify | 保持现有导出签名；增加 Rust 调用适配（BEAUTIFUL_MERMAID_USE_RUST=1 启用），并在 Rust 调用失败时回退 TS 纯实现。 |
| `crates/beautiful-mermaid-rs/src/utils.rs` | modify | 实现与 TS 等价的 multiline 工具函数与格式标签解析逻辑；重点对齐正则顺序、大小写、嵌套和空白边界行为。 |
| `crates/beautiful-mermaid-rs/src/lib.rs` | modify | 导出 utils 模块的公开函数，供 NAPI 层调用。 |
| `crates/beautiful-mermaid-napi/src/lib.rs` | modify | 新增 NAPI 绑定函数（normalize/strip/escape/render*），返回值类型与 TS 现有函数对齐。 |
| `crates/beautiful-mermaid-napi/index.js` | modify | 导出新增 addon 方法，命名与 TS 适配层调用保持一致。 |
| `src/__tests__/multiline-utils.unit.test.ts` | create | 新增 Rust↔TS 对照单测：同一输入分别走 TS 和 Rust，实现结果逐项严格相等。 |
| `src/__tests__/multiline-labels.test.ts` | modify | 补充/参数化开关场景（默认 TS + Rust 开关），确保端到端渲染输出一致。 |
| `.github/workflows/ci.yml` | modify | 将新增单测纳入 CI，并增加 Rust 开关路径测试，防止仅默认路径通过导致回归。 |

### 测试场景

1. **BR 标签归一化**: 输入 `a<br>b | a<br/>b | a<br />b | a<BR>b` → 预期 `统一输出为 a\nb`
2. **字面换行转真实换行**: 输入 `a\\nb` → 预期 `a\nb`
3. **Markdown bold**: 输入 `**text**` → 预期 `<b>text</b>`
4. **Markdown italic 边界**: 输入 `*a* 与 * a *` → 预期 `前者转 <i>a</i>，后者保持原样`
5. **Markdown strike**: 输入 `~~text~~` → 预期 `<s>text</s>`
6. **嵌套格式标签**: 输入 `<b><i>text</i></b>` → 预期 `生成同时包含 bold+italic 的 tspan`
7. **特殊标签移除**: 输入 `H<sub>2</sub>O 与 x<sup>2</sup>` → 预期 `H2O 与 x2`
8. **XML 转义**: 输入 `& < > " '` → 预期 `&amp; &lt; &gt; &quot; &#39;`
9. **多行 dy 计算**: 输入 `line1\nline2\nline3, fontSize=16` → 预期 `首行 dy 为负向居中偏移+baseline，其余行 dy 为 lineHeight`


---
*方案已定稿，即将开始实现。*
<!-- PLAN_FILES:[{"path":"src/multiline-utils.ts","action":"modify","description":"保持现有导出签名；增加 Rust 调用适配（BEAUTIFUL_MERMAID_USE_RUST=1 启用），并在 Rust 调用失败时回退 TS 纯实现。"},{"path":"crates/beautiful-mermaid-rs/src/utils.rs","action":"modify","description":"实现与 TS 等价的 multiline 工具函数与格式标签解析逻辑；重点对齐正则顺序、大小写、嵌套和空白边界行为。"},{"path":"crates/beautiful-mermaid-rs/src/lib.rs","action":"modify","description":"导出 utils 模块的公开函数，供 NAPI 层调用。"},{"path":"crates/beautiful-mermaid-napi/src/lib.rs","action":"modify","description":"新增 NAPI 绑定函数（normalize/strip/escape/render*），返回值类型与 TS 现有函数对齐。"},{"path":"crates/beautiful-mermaid-napi/index.js","action":"modify","description":"导出新增 addon 方法，命名与 TS 适配层调用保持一致。"},{"path":"src/__tests__/multiline-utils.unit.test.ts","action":"create","description":"新增 Rust↔TS 对照单测：同一输入分别走 TS 和 Rust，实现结果逐项严格相等。"},{"path":"src/__tests__/multiline-labels.test.ts","action":"modify","description":"补充/参数化开关场景（默认 TS + Rust 开关），确保端到端渲染输出一致。"},{"path":".github/workflows/ci.yml","action":"modify","description":"将新增单测纳入 CI，并增加 Rust 开关路径测试，防止仅默认路径通过导致回归。"},{"path":"Cargo.lock","action":"modify","description":"自动同步：根据 PR 实际改动补齐（status=modified）"},{"path":"crates/beautiful-mermaid-napi/Cargo.toml","action":"modify","description":"自动同步：根据 PR 实际改动补齐（status=modified）"},{"path":"src/__tests__/napi-smoke.test.ts","action":"modify","description":"自动同步：根据 PR 实际改动补齐（status=modified）"}] -->